### PR TITLE
[SDK] Option to have no printf when running on realtime loop

### DIFF
--- a/sdk/master_board_sdk/src/master_board_interface.cpp
+++ b/sdk/master_board_sdk/src/master_board_interface.cpp
@@ -113,7 +113,8 @@ void MasterBoardInterface::callback(uint8_t src_mac[6], uint8_t *data, int len)
 {
   if (len != sizeof(sensor_packet_t))
   {
-    printf("received a %d long packet\n", len);
+    // Commented printf because it can be problematic for realtime thread
+    // printf("received a %d long packet\n", len);
     return;
   }
 


### PR DESCRIPTION
Associated with Issue #19 

* `printf("received a %d long packet\n", len);` has been commented in `MasterBoardInterface::callback`
* A new `nb_long_packets` property has been added to the MasterBoardInterface class to log the number of long packet instances
* `printf("%d long packets have been received\n", nb_long_packets);` has been added to `MasterBoardInterface::Stop` to display the number of long packet instances when the connexion is being shut down at the end of an experiment

`example.cpp` compiles but I cannot test it for now.
