### PR TITLE
[SDK] Adapting gains for SI units + Python bindings for adc property …

### DIFF
--- a/sdk/master_board_sdk/include/master_board_sdk/master_board_interface.h
+++ b/sdk/master_board_sdk/include/master_board_sdk/master_board_interface.h
@@ -61,8 +61,6 @@ public:
 
 	// Get functions for Python binding with Boost
 	uint16_t get_nb_recv() { return this->nb_recv; };
-	Motor* get_motors() { return this->motors; };
-	MotorDriver* get_motor_drivers() { return this->motor_drivers; };
 	MotorDriver* GetDriver(int i) { return &(this->motor_drivers[i]); };
 	Motor* GetMotor(int i) { return &(this->motors[i]); };
 

--- a/sdk/master_board_sdk/include/master_board_sdk/motor_driver.h
+++ b/sdk/master_board_sdk/include/master_board_sdk/motor_driver.h
@@ -44,6 +44,7 @@ public:
 	void set_enable(bool val) { this->enable = val;};
 	void set_enable_position_rollover_error(bool val) { this->enable_position_rollover_error = val; };
 	void set_timeout(uint8_t val) { this->timeout = val; };
+	void set_adc(float adc_val []); // See definition in .cpp
 
 	// Get functions for Python binding with Boost
   	Motor* get_motor1() { return (this->motor1); };

--- a/sdk/master_board_sdk/src/motor_driver.cpp
+++ b/sdk/master_board_sdk/src/motor_driver.cpp
@@ -35,11 +35,22 @@ void MotorDriver::EnablePositionRolloverError()
 {
   enable_position_rollover_error = true;
 }
+
 void MotorDriver::DisablePositionRolloverError()
 {
   enable_position_rollover_error = false;
 }
+
 void MotorDriver::SetTimeout(uint8_t time)
 {
   timeout = time;
 }
+
+void MotorDriver::set_adc(float adc_val [])
+{
+  // The adc property is defined as float adc[2]
+  (this->adc)[0] = adc_val[0];
+  (this->adc)[1] = adc_val[1];
+}
+
+

--- a/sdk/master_board_sdk/srcpy/my_bindings_headr.cpp
+++ b/sdk/master_board_sdk/srcpy/my_bindings_headr.cpp
@@ -1,6 +1,18 @@
 #include "my_bindings_headr.h"
 
-    using namespace boost::python;
+using namespace boost::python;
+
+// Wrapper to access the adc property, an array of 2 floats (read-only access)) 
+boost::python::tuple wrap_adc(MotorDriver const * motDriver) 
+{
+  boost::python::list a;
+  for (int i = 0; i < 2; ++i) 
+  {
+    a.append(motDriver->adc[i]);
+  }
+  return boost::python::tuple(a);
+}
+
 
     BOOST_PYTHON_MODULE(libmaster_board_sdk_pywrap)
     {
@@ -19,6 +31,7 @@
             .def("SendCommand", &MasterBoardInterface::SendCommand)
             .def("ParseSensorData", &MasterBoardInterface::ParseSensorData)
             .def("PrintIMU", &MasterBoardInterface::PrintIMU)
+            .def("PrintADC", &MasterBoardInterface::PrintADC)
             .def("PrintMotors", &MasterBoardInterface::PrintMotors)
             .def("PrintMotorDrivers", &MasterBoardInterface::PrintMotorDrivers)
             .def("GetDriver", make_function(&MasterBoardInterface::GetDriver, return_value_policy<boost::python::reference_existing_object>()))
@@ -84,7 +97,7 @@
             .def("SetTimeout", &MotorDriver::SetTimeout)
             .def("Enable", &MotorDriver::Enable)
             .def("Disable", &MotorDriver::Disable)
-
+            
             // Public properties of MotorDriver class
             .add_property("motor1", make_function(&MotorDriver::get_motor1, return_value_policy<boost::python::reference_existing_object>()), &MotorDriver::set_motor1)
             .add_property("motor2", make_function(&MotorDriver::get_motor2, return_value_policy<boost::python::reference_existing_object>()), &MotorDriver::set_motor2)
@@ -93,6 +106,7 @@
             .add_property("enable", &MotorDriver::get_enable, &MotorDriver::set_enable)
             .add_property("enable_position_rollover_error", &MotorDriver::get_enable_position_rollover_error, &MotorDriver::set_enable_position_rollover_error)
             .add_property("timeout", &MotorDriver::get_timeout, &MotorDriver::set_timeout)
+            .add_property("adc", wrap_adc)
         ;
         // End of bindings for MotorDriver class
 


### PR DESCRIPTION
…and printADC function

Since we are now using radians, the previous control gains in example.py were no longer valid. I copied in example.py the gains that were put in example.cpp by pull request #14 

I also did the Python bindings for the adc property and the printADC function introduced in pull request #9. adc property is currently read-only in Python. 

Both .cpp and .py have been tested and are working properly on the test bench.