### PR TITLE
[SDK] Python bindings for IMU data (accelerometer, gyroscope, attitude)

### DIFF
--- a/sdk/master_board_sdk/example/example.py
+++ b/sdk/master_board_sdk/example/example.py
@@ -71,6 +71,8 @@ def example_script(name_interface):
 
             if ((cpt % 100) == 0):  # Display state of the system once every 100 iterations of the main loop
                 print(chr(27) + "[2J")
+                # To read IMU data in Python use robot_if.imu_data_accelerometer(i), robot_if.imu_data_gyroscope(i)
+                # or robot_if.imu_data_attitude(i) with i = 0, 1 or 2
                 robot_if.PrintIMU()
                 robot_if.PrintADC()
                 robot_if.PrintMotors()

--- a/sdk/master_board_sdk/include/master_board_sdk/master_board_interface.h
+++ b/sdk/master_board_sdk/include/master_board_sdk/master_board_interface.h
@@ -63,6 +63,9 @@ public:
 	uint16_t get_nb_recv() { return this->nb_recv; };
 	MotorDriver* GetDriver(int i) { return &(this->motor_drivers[i]); };
 	Motor* GetMotor(int i) { return &(this->motors[i]); };
+	float imu_data_accelerometer(int i) { return (this->imu_data.accelerometer[i]); };
+	float imu_data_gyroscope(int i) { return (this->imu_data.gyroscope[i]); };
+	float imu_data_attitude(int i) { return (this->imu_data.attitude[i]); };
 
 };
 

--- a/sdk/master_board_sdk/srcpy/my_bindings_headr.cpp
+++ b/sdk/master_board_sdk/srcpy/my_bindings_headr.cpp
@@ -36,6 +36,9 @@ boost::python::tuple wrap_adc(MotorDriver const * motDriver)
             .def("PrintMotorDrivers", &MasterBoardInterface::PrintMotorDrivers)
             .def("GetDriver", make_function(&MasterBoardInterface::GetDriver, return_value_policy<boost::python::reference_existing_object>()))
             .def("GetMotor", make_function(&MasterBoardInterface::GetMotor, return_value_policy<boost::python::reference_existing_object>()))
+            .def("imu_data_accelerometer", make_function(&MasterBoardInterface::imu_data_accelerometer))
+            .def("imu_data_gyroscope", make_function(&MasterBoardInterface::imu_data_gyroscope))
+            .def("imu_data_attitude", make_function(&MasterBoardInterface::imu_data_attitude))
 
             // Public properties of MasterBoardInterface class
             .add_property("nb_recv", &MasterBoardInterface::get_nb_recv, &MasterBoardInterface::set_nb_recv)


### PR DESCRIPTION
Pull request for issue #27 

To access IMU data in Python (read-only) you can use `robot_if.imu_data_accelerometer(i)`, `robot_if.imu_data_gyroscope(i)` or `robot_if.imu_data_attitude(i)` with i = 0, 1 or 2. 

For instance `print("Accelerometer: ", robot_if.imu_data_accelerometer(0), robot_if.imu_data_accelerometer(1), robot_if.imu_data_accelerometer(2))`

`robot_if` is the name of the MasterBoardInterface that is used in `example.py` :
`robot_if = mbs.MasterBoardInterface(name_interface)`