### PR TITLE
[SDK] Timeout of MasterBoardInterface if the master board is not resp…

### DIFF
--- a/sdk/master_board_sdk/example/example.cpp
+++ b/sdk/master_board_sdk/example/example.cpp
@@ -40,7 +40,7 @@ int main(int argc, char **argv)
 		robot_if.motor_drivers[i].Enable();
 	}
 	std::chrono::time_point<std::chrono::system_clock> last = std::chrono::system_clock::now();
-	while (1)
+	while (!robot_if.IsTimeout())
 	{
 		if (((std::chrono::duration<double>)(std::chrono::system_clock::now() - last)).count() > dt)
 		{
@@ -98,5 +98,6 @@ int main(int argc, char **argv)
 			std::this_thread::yield();
 		}
 	}
+        printf("Masterboard timeout detected. Either the masterboard has been shut down or there has been a connection issue with the cable/wifi.\n");
 	return 0;
 }

--- a/sdk/master_board_sdk/example/example.py
+++ b/sdk/master_board_sdk/example/example.py
@@ -40,7 +40,7 @@ def example_script(name_interface):
 
     last = clock()
 
-    while (clock() < 20):  # Stop after 15 seconds (around 5 seconds are used at the start for calibration)
+    while ((not robot_if.IsTimeout()) and (clock() < 20)):  # Stop after 15 seconds (around 5 seconds are used at the start for calibration)
 
         if ((clock() - last) > dt):
             last = clock()
@@ -80,6 +80,9 @@ def example_script(name_interface):
             robot_if.SendCommand()  # Send the reference currents to the master board
 
     robot_if.Stop()  # Shut down the interface between the computer and the master board
+
+    if robot_if.IsTimeout():
+        print("Masterboard timeout detected. Either the masterboard has been shut down or there has been a connection issue with the cable/wifi.")
 
     print("-- End of example script --")
 

--- a/sdk/master_board_sdk/srcpy/my_bindings_headr.cpp
+++ b/sdk/master_board_sdk/srcpy/my_bindings_headr.cpp
@@ -34,6 +34,8 @@ boost::python::tuple wrap_adc(MotorDriver const * motDriver)
             .def("PrintADC", &MasterBoardInterface::PrintADC)
             .def("PrintMotors", &MasterBoardInterface::PrintMotors)
             .def("PrintMotorDrivers", &MasterBoardInterface::PrintMotorDrivers)
+            .def("ResetTimeout", &MasterBoardInterface::ResetTimeout)
+            .def("IsTimeout", &MasterBoardInterface::IsTimeout)
             .def("GetDriver", make_function(&MasterBoardInterface::GetDriver, return_value_policy<boost::python::reference_existing_object>()))
             .def("GetMotor", make_function(&MasterBoardInterface::GetMotor, return_value_policy<boost::python::reference_existing_object>()))
 


### PR DESCRIPTION
…onding

Pull request for issue #22 

After 50 ms without receiving a packet from the master board a timeout is triggered and the MasterBoardInterface is shutdown. 

The timeout is a security measure to avoid the following issue: if a control program is running on your desktop computer/laptop and the robot is powered down then powered on again, the control program immediately sends control packets as soon as the master board is ready and the robot starts moving, which could be dangerous. With the timeout no packet will be sent until you call `ResetTimeout()` or just restart the control program.