### PR TITLE
Increase the communication timeout from 50 ms to 1000 ms.

### DIFF
--- a/sdk/master_board_sdk/include/master_board_sdk/master_board_interface.h
+++ b/sdk/master_board_sdk/include/master_board_sdk/master_board_interface.h
@@ -54,9 +54,9 @@ private:
 
 	std::mutex sensor_packet_mutex;
 
-	// Time duration [s] after which the MasterBoardInterface shuts down if the
-	// master board is not responding (timeout)
-	std::chrono::milliseconds t_before_shutdown{50};
+	// Time duration [ms] after which the MasterBoardInterface shuts down if the
+	// master board is not responding (timeout).
+	std::chrono::milliseconds t_before_shutdown{1000};
 
 	// Time point that is updated each time a packet is received
 	std::chrono::high_resolution_clock::time_point t_last_packet = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
This is followup to #30 .

When running the latest code in #30 in our dynamic graph manager setup, it seems there is sometimes a longer than 50 ms delay during startup. Increasing the value to 1000 ms makes our setup work.