### PR TITLE
[Python] replace getopt by argparse

### DIFF
--- a/sdk/master_board_sdk/example/example.py
+++ b/sdk/master_board_sdk/example/example.py
@@ -1,10 +1,11 @@
 # coding: utf8
 
-from time import clock
-import math
-import sys
 import getopt
+import math
 import os
+import sys
+from time import clock
+
 import libmaster_board_sdk_pywrap as mbs
 
 
@@ -40,7 +41,8 @@ def example_script(name_interface):
 
     last = clock()
 
-    while ((not robot_if.IsTimeout()) and (clock() < 20)):  # Stop after 15 seconds (around 5 seconds are used at the start for calibration)
+    while ((not robot_if.IsTimeout())
+           and (clock() < 20)):  # Stop after 15 seconds (around 5 seconds are used at the start for calibration)
 
         if ((clock() - last) > dt):
             last = clock()
@@ -84,7 +86,8 @@ def example_script(name_interface):
     robot_if.Stop()  # Shut down the interface between the computer and the master board
 
     if robot_if.IsTimeout():
-        print("Masterboard timeout detected. Either the masterboard has been shut down or there has been a connection issue with the cable/wifi.")
+        print("Masterboard timeout detected.")
+        print("Either the masterboard has been shut down or there has been a connection issue with the cable/wifi.")
 
     print("-- End of example script --")
 

--- a/sdk/master_board_sdk/example/example.py
+++ b/sdk/master_board_sdk/example/example.py
@@ -1,6 +1,6 @@
 # coding: utf8
 
-import getopt
+import argparse
 import math
 import os
 import sys
@@ -92,22 +92,15 @@ def example_script(name_interface):
     print("-- End of example script --")
 
 
-def main(argv):
-    name_interface = ""  # Name of the interface (use ifconfig in a terminal), for instance "enp1s0"
-    try:
-        opts, args = getopt.getopt(argv, "hi:")
-    except getopt.GetoptError:
-        print("example.py -i <interface>")
-        sys.exit(2)
-    for opt, arg in opts:
-        if opt == '-h':
-            print("example.py -i <interface>")
-            sys.exit()
-        elif opt in ("-i") and isinstance(arg, str):
-            name_interface = arg
-    print("name_interface: ", name_interface)
-    example_script(name_interface)
+def main():
+    parser = argparse.ArgumentParser(description='Example masterboard use in python.')
+    parser.add_argument('-i',
+                        '--interface',
+                        required=True,
+                        help='Name of the interface (use ifconfig in a terminal), for instance "enp1s0"')
+
+    example_script(parser.parse_args().interface)
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    main()


### PR DESCRIPTION
Which is cleaner, and comes with more functionnalities.

Eg.:
```
╰─>$ python3 example/example.py 
usage: example.py [-h] -i INTERFACE
example.py: error: the following arguments are required: -i/--interface
╰─>$ python3 example/example.py -h
usage: example.py [-h] -i INTERFACE

Example masterboard use in python.

optional arguments:
  -h, --help            show this help message and exit
  -i INTERFACE, --interface INTERFACE
                        Name of the interface (use ifconfig in a terminal),
                        for instance "enp1s0"
```