### PR TITLE
[SDK] Small guide on how to compile and launch the Python example

### DIFF
--- a/sdk/master_board_sdk/README.md
+++ b/sdk/master_board_sdk/README.md
@@ -28,7 +28,7 @@ sudo ./setup_wifi.sh MY_INTERFACE
 ``` 
 where MY_INTERFACE your wlan interface name.
 
-How to run the example
+How to run the C++ example
 --------
 main.cpp is a simple example to test the SDK, tested on ubuntu.
 It will execute a sinusoid trajectory on the first N_CONTROLLED_SLAVE 
@@ -42,3 +42,27 @@ to run the example run:
 sudo ./bin/exec MY_INTERFACE
 ```
 where MY_INTERFACE is the name of the network interface used to connect to the master board.
+
+How to run the Python example
+--------
+
+* Clone the repository: `git clone --recursive https://github.com/open-dynamic-robot-initiative/master-board.git`
+
+* Get into the repository: `cd master-board`
+
+* Set the number of controlled drivers by opening `sdk/master_board_sdk/example/example.py` and tuning the `N_SLAVES_CONTROLED` constant: `N_SLAVES_CONTROLED 4` if you are using 4 driver boards (1 per leg)
+
+* Get in `sdk/master_board_sdk/`: `cd sdk/master_board_sdk/`
+
+* Create a build folder: `mkdir build`
+
+* Get into the folder: `cd build`
+
+* Two possibilities:
+    * Using `ccmake ..` turn on Python bindings by setting `BUILD_PYTHON_INTERFACE` to `ON` and `CMAKE_BUILD_TYPE` to `RELEASE`. Then compile and create the bindings: `cmake ..` then `make`
+    * Directly use `cmake -DBUILD_PYTHON_INTERFACE=ON -DCMAKE_BUILD_TYPE=RELEASE ..` then `make`. If you want to run the scripts with Python 3 then use `cmake -DBUILD_PYTHON_INTERFACE=ON -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=$(which python3) ..` instead.
+
+* Run the control script with the name of your Ethernet interface instead of `name_interface` (for instance `enp1s0`): 
+
+`sudo PYTHONPATH=. python example/example.pyc -i name_interface`
+

--- a/sdk/master_board_sdk/include/master_board_sdk/defines.h
+++ b/sdk/master_board_sdk/include/master_board_sdk/defines.h
@@ -3,7 +3,6 @@
 
 #include "master_board_sdk/protocol.h"
 #define N_SLAVES 6
-#define N_SLAVES_CONTROLED 4
 
 struct dual_motor_driver_sensor_packet_t
 {


### PR DESCRIPTION
Small guide on how to use the Python example script.

It takes into account the changes of #33  (the last command `sudo PYTHONPATH=. python example/example.pyc -i name_interface` is new compared to what I wrote in previous pull requests).