### PR TITLE
[sdk] Fix velocity si unit conversion. Fixes #38

### DIFF
--- a/sdk/master_board_sdk/example/example.cpp
+++ b/sdk/master_board_sdk/example/example.cpp
@@ -17,7 +17,7 @@ int main(int argc, char **argv)
 	double dt = 0.001;
 	double t = 0;
 	double kp = 5.;
-	double kd = 0.5;
+	double kd = 0.1;
 	double iq_sat = 4.0;
 	double freq = 0.5;
 	double amplitude = M_PI;

--- a/sdk/master_board_sdk/src/master_board_interface.cpp
+++ b/sdk/master_board_sdk/src/master_board_interface.cpp
@@ -17,7 +17,7 @@ MasterBoardInterface::MasterBoardInterface(const std::string &if_name)
 }
 MasterBoardInterface::MasterBoardInterface(const MasterBoardInterface& to_be_copied) : MasterBoardInterface::MasterBoardInterface(to_be_copied.if_name_)
 {
-  
+
 }
 int MasterBoardInterface::Init()
 {
@@ -67,7 +67,7 @@ int MasterBoardInterface::SendCommand()
 {
   // If the MasterBoardInterface has been shutdown due to a timeout we don't want to
   // send another command before the user manually reset the timeout state
-  if (timeout) 
+  if (timeout)
   {
     return -1; // Return -1 since the command has not been sent.
   }
@@ -104,25 +104,25 @@ int MasterBoardInterface::SendCommand()
     command_packet.dual_motor_driver_command_packets[i].mode = mode;
     command_packet.dual_motor_driver_command_packets[i].position_ref[0] = FLOAT_TO_D16QN(motor_drivers[i].motor1->position_ref / (2. * M_PI), UD_QN_POS);
     command_packet.dual_motor_driver_command_packets[i].position_ref[1] = FLOAT_TO_D16QN(motor_drivers[i].motor2->position_ref / (2. * M_PI), UD_QN_POS);
-    command_packet.dual_motor_driver_command_packets[i].velocity_ref[0] = FLOAT_TO_D16QN(motor_drivers[i].motor1->velocity_ref * 60. / 1000., UD_QN_VEL);
-    command_packet.dual_motor_driver_command_packets[i].velocity_ref[1] = FLOAT_TO_D16QN(motor_drivers[i].motor2->velocity_ref * 60. / 1000., UD_QN_VEL);
+    command_packet.dual_motor_driver_command_packets[i].velocity_ref[0] = FLOAT_TO_D16QN(motor_drivers[i].motor1->velocity_ref * 60. / (2. * M_PI * 1000.), UD_QN_VEL);
+    command_packet.dual_motor_driver_command_packets[i].velocity_ref[1] = FLOAT_TO_D16QN(motor_drivers[i].motor2->velocity_ref * 60. / (2. * M_PI * 1000.), UD_QN_VEL);
     command_packet.dual_motor_driver_command_packets[i].current_ref[0] = FLOAT_TO_D16QN(motor_drivers[i].motor1->current_ref, UD_QN_IQ);
     command_packet.dual_motor_driver_command_packets[i].current_ref[1] = FLOAT_TO_D16QN(motor_drivers[i].motor2->current_ref, UD_QN_IQ);
     command_packet.dual_motor_driver_command_packets[i].kp[0] = FLOAT_TO_D16QN(2. * M_PI * motor_drivers[i].motor1->kp, UD_QN_ISAT);
-    command_packet.dual_motor_driver_command_packets[i].kp[1] = FLOAT_TO_D16QN(2. * M_PI *motor_drivers[i].motor2->kp, UD_QN_ISAT);
-    command_packet.dual_motor_driver_command_packets[i].kd[0] = FLOAT_TO_D16QN(1000. / 60. * motor_drivers[i].motor1->kd, UD_QN_ISAT);
-    command_packet.dual_motor_driver_command_packets[i].kd[1] = FLOAT_TO_D16QN(1000. / 60. * motor_drivers[i].motor2->kd, UD_QN_ISAT);
+    command_packet.dual_motor_driver_command_packets[i].kp[1] = FLOAT_TO_D16QN(2. * M_PI * motor_drivers[i].motor2->kp, UD_QN_ISAT);
+    command_packet.dual_motor_driver_command_packets[i].kd[0] = FLOAT_TO_D16QN(2. * M_PI * 1000. / 60. * motor_drivers[i].motor1->kd, UD_QN_ISAT);
+    command_packet.dual_motor_driver_command_packets[i].kd[1] = FLOAT_TO_D16QN(2. * M_PI * 1000. / 60. * motor_drivers[i].motor2->kd, UD_QN_ISAT);
   }
 
   // Current time point
 	std::chrono::high_resolution_clock::time_point t_send_packet = std::chrono::high_resolution_clock::now();
 
 	// Assess time duration since the last packet has been received
-	std::chrono::duration<double, std::milli> time_span = t_send_packet - t_last_packet; 
+	std::chrono::duration<double, std::milli> time_span = t_send_packet - t_last_packet;
 
 	// If this duration is greater than the timeout limit duration
 	// then the packet is not sent and the connection with the master board is closed
-	if (time_span > t_before_shutdown) 
+	if (time_span > t_before_shutdown)
 	{
     timeout = true;
     Stop();
@@ -130,7 +130,7 @@ int MasterBoardInterface::SendCommand()
 	}
 
   link_handler_->send((uint8_t *)&command_packet, sizeof(command_packet_t));
-  
+
   return 0; // Return 0 since the command has been sent.
 }
 
@@ -178,7 +178,7 @@ void MasterBoardInterface::ParseSensorData()
 
     //motor 1
     motor_drivers[i].motor1->position = 2. * M_PI * D32QN_TO_FLOAT(sensor_packet.dual_motor_driver_sensor_packets[i].position[0], UD_QN_POS);
-    motor_drivers[i].motor1->velocity = 1000. / 60. * D32QN_TO_FLOAT(sensor_packet.dual_motor_driver_sensor_packets[i].velocity[0], UD_QN_VEL);
+    motor_drivers[i].motor1->velocity = 2. * M_PI * 1000. / 60. * D32QN_TO_FLOAT(sensor_packet.dual_motor_driver_sensor_packets[i].velocity[0], UD_QN_VEL);
     motor_drivers[i].motor1->current = D32QN_TO_FLOAT(sensor_packet.dual_motor_driver_sensor_packets[i].current[0], UD_QN_IQ);
     motor_drivers[i].motor1->is_enabled = sensor_packet.dual_motor_driver_sensor_packets[i].status & UD_SENSOR_STATUS_M1E;
     motor_drivers[i].motor1->is_ready = sensor_packet.dual_motor_driver_sensor_packets[i].status & UD_SENSOR_STATUS_M1R;
@@ -187,7 +187,7 @@ void MasterBoardInterface::ParseSensorData()
 
     //motor 2
     motor_drivers[i].motor2->position = 2. * M_PI * D32QN_TO_FLOAT(sensor_packet.dual_motor_driver_sensor_packets[i].position[1], UD_QN_POS);
-    motor_drivers[i].motor2->velocity = 1000. / 60. * D32QN_TO_FLOAT(sensor_packet.dual_motor_driver_sensor_packets[i].velocity[1], UD_QN_VEL);
+    motor_drivers[i].motor2->velocity = 2. * M_PI * 1000. / 60. * D32QN_TO_FLOAT(sensor_packet.dual_motor_driver_sensor_packets[i].velocity[1], UD_QN_VEL);
     motor_drivers[i].motor2->current = D32QN_TO_FLOAT(sensor_packet.dual_motor_driver_sensor_packets[i].current[1], UD_QN_IQ);
     motor_drivers[i].motor2->is_enabled = sensor_packet.dual_motor_driver_sensor_packets[i].status & UD_SENSOR_STATUS_M2E;
     motor_drivers[i].motor2->is_ready = sensor_packet.dual_motor_driver_sensor_packets[i].status & UD_SENSOR_STATUS_M2R;


### PR DESCRIPTION
This fixes the missing `2. * M_PI *` in the the velocity measurements.

Note: After landing this PR, you will need to adjust your d gains (as shown in the example). The existing gains should be divided by roughly `2. * M_PI`.

I've tested this PR with the example on our testbench.