### PR TITLE
Timeout of the SendCommand only after the first command

### DIFF
--- a/sdk/master_board_sdk/include/master_board_sdk/master_board_interface.h
+++ b/sdk/master_board_sdk/include/master_board_sdk/master_board_interface.h
@@ -59,7 +59,11 @@ private:
 	std::chrono::milliseconds t_before_shutdown{50};
 
 	// Time point that is updated each time a packet is received
-	std::chrono::high_resolution_clock::time_point t_last_packet = std::chrono::high_resolution_clock::now();
+	std::chrono::high_resolution_clock::time_point t_last_packet =
+            std::chrono::high_resolution_clock::now();
+       // We initialize this value only upon the first call of SendCommand
+       bool first_command_sent_ = false;
+
 
 	// Is true if the MasterBoardInterface has been shut down due to timeout
 	bool timeout = false;

--- a/sdk/master_board_sdk/src/master_board_interface.cpp
+++ b/sdk/master_board_sdk/src/master_board_interface.cpp
@@ -65,8 +65,18 @@ int MasterBoardInterface::Stop()
 
 int MasterBoardInterface::SendCommand()
 {
-  // If the MasterBoardInterface has been shutdown due to a timeout we don't want to
-  // send another command before the user manually reset the timeout state
+  // If SendCommand is not called every N milli-second we shutdown the
+  // connexion. This check is performed only from the first time SendCommand
+  // is called. See the comment below for more information.
+  if(!first_command_sent_)
+  {
+    t_last_packet = std::chrono::high_resolution_clock::now();
+    first_command_sent_ = true;
+  }
+
+  // If the MasterBoardInterface has been shutdown due to a timeout we don't
+  // want to send another command before the user manually reset the timeout
+  // state
   if (timeout)
   {
     return -1; // Return -1 since the command has not been sent.


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."

This PR concerns the timeout from 2 consecutive call of the master_board_sdk SendCommand API.
It only checks the timeout from the first time one uses the SendCommand method.

## How I Tested

[//]: # "Explain how you tested your changes"

I tested it on the solo12 robot in MPI-IS Tubingen.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [ ] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
