### PR TITLE
[sdk] rescale linear acceleration to SI, fix typo in python bindings

### DIFF
--- a/sdk/master_board_sdk/src/master_board_interface.cpp
+++ b/sdk/master_board_sdk/src/master_board_interface.cpp
@@ -172,7 +172,7 @@ void MasterBoardInterface::ParseSensorData()
     imu_data.accelerometer[i] = 9.80665 * D16QN_TO_FLOAT(sensor_packet.imu.accelerometer[i], IMU_QN_ACC);
     imu_data.gyroscope[i] = D16QN_TO_FLOAT(sensor_packet.imu.gyroscope[i], IMU_QN_GYR);
     imu_data.attitude[i] = D16QN_TO_FLOAT(sensor_packet.imu.attitude[i], IMU_QN_EF);
-    imu_data.linear_acceleration[i] = 9.80665 * D16QN_TO_FLOAT(sensor_packet.imu.linear_acceleration[i], IMU_QN_ACC);
+    imu_data.linear_acceleration[i] = D16QN_TO_FLOAT(sensor_packet.imu.linear_acceleration[i], IMU_QN_ACC);
   }
 
 

--- a/sdk/master_board_sdk/srcpy/my_bindings_headr.cpp
+++ b/sdk/master_board_sdk/srcpy/my_bindings_headr.cpp
@@ -69,7 +69,7 @@ boost::python::tuple wrap_adc(MotorDriver const * motDriver)
             .def("GetPosition", &Motor::GetPosition)
             .def("GetPositionOffset", &Motor::GetPositionOffset)
             .def("GetVelocity", &Motor::GetVelocity)
-            .def("GetCurent", &Motor::GetCurrent)
+            .def("GetCurrent", &Motor::GetCurrent)
 
             // Public properties of Motor class
             .add_property("position", &Motor::get_position, &Motor::set_position)


### PR DESCRIPTION
rescale linear acceleration to SI
fix typo in python bindings