### PR TITLE
LinkManager: Close connection on destruction

### DIFF
--- a/sdk/master_board_sdk/include/master_board_sdk/Link_manager.h
+++ b/sdk/master_board_sdk/include/master_board_sdk/Link_manager.h
@@ -30,6 +30,7 @@ public:
 	{
 		set_interface(interface);
 	}
+	~LINK_manager();
 
 	void set_recv_callback(LINK_manager_callback *);
 	void set_interface(const std::string &interface);

--- a/sdk/master_board_sdk/src/Link_manager.cpp
+++ b/sdk/master_board_sdk/src/Link_manager.cpp
@@ -87,6 +87,12 @@ void LINK_manager::end()
 	stop();
 }
 
+
+LINK_manager::~LINK_manager()
+{
+	end();
+}
+
 void *LINK_manager::sock_recv_thread(void *p_arg)
 {
 	int raw_bytes_len;


### PR DESCRIPTION
It's good practice to close the resources that got allocated during destruction. This PR does this for the link manager.