### PR TITLE
Add local joint impedance control interface + improve python binding packaging 

### DIFF
--- a/documentation/BLMC_µDriver_SPI_interface.md
+++ b/documentation/BLMC_µDriver_SPI_interface.md
@@ -124,5 +124,5 @@ Iq | 16bits | A | -32 | 31,9990234375 | 2^(-10) | This can be use as a feed-forw
 I_sat | 8 bits | A | 0 | 31,875 | 2^(-3) | Current saturation, useful when using Kp>0 or Kd>0
 Coil resistance | 16bits | Ohm | 0 | 1,9999694824 | 2^(-15) | Useful to estimated coil temperature from U/I (Not implemented yet)
 ADC | 16bits | V | 0 | 3.99993896484 | 2^(-14) | |
-Kp | 16bits | A/rot | 0 | 127.998046875 | 2^(-9) | Setting Kp=Kd=0 allow to do direct current control |
-Kd | 16bits | A/k rpm | 0 | 127.998046875 | 2^(-9) | Setting Kp=Kd=0 allow to do direct current control |
+Kp | 16bits | A/rot | 0 | 31.99951171875 | 2^(-11) | Setting Kp=Kd=0 allow to do direct current control |
+Kd | 16bits | A/k rpm | 0 | 63.9990234375 | 2^(-10) | Setting Kp=Kd=0 allow to do direct current control |

--- a/documentation/BLMC_µDriver_SPI_interface.md
+++ b/documentation/BLMC_µDriver_SPI_interface.md
@@ -124,5 +124,5 @@ Iq | 16bits | A | -32 | 31,9990234375 | 2^(-10) | This can be use as a feed-forw
 I_sat | 8 bits | A | 0 | 31,875 | 2^(-3) | Current saturation, useful when using Kp>0 or Kd>0
 Coil resistance | 16bits | Ohm | 0 | 1,9999694824 | 2^(-15) | Useful to estimated coil temperature from U/I (Not implemented yet)
 ADC | 16bits | V | 0 | 3.99993896484 | 2^(-14) | |
-Kp | 16bits | A/rot | 0 | | TODO... | Setting Kp=Kd=0 allow to do direct current control |
-Kd | 16bits | A/k rpm | 0 | | TODO... | Setting Kp=Kd=0 allow to do direct current control |
+Kp | 16bits | A/rot | 0 | 127.998046875 | 2^(-9) | Setting Kp=Kd=0 allow to do direct current control |
+Kd | 16bits | A/k rpm | 0 | 127.998046875 | 2^(-9) | Setting Kp=Kd=0 allow to do direct current control |

--- a/sdk/master_board_sdk/CMakeLists.txt
+++ b/sdk/master_board_sdk/CMakeLists.txt
@@ -2,14 +2,13 @@
 # Copyright (c) 2019 CNRS
 #
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
 
 # ----------------------------------------------------
 # --- CXX FLAGS --------------------------------------
 # ----------------------------------------------------
 
 ADD_DEFINITIONS(-pthread)
-SET(CMAKE_CXX_STANDARD 11)
 SET(CXX_DISABLE_WERROR True)
 SET(CMAKE_VERBOSE_MAKEFILE True)
 
@@ -18,6 +17,11 @@ SET(PROJECT_NAME master-board-sdk)
 SET(PROJECT_DESCRIPTION "This project contains the sdk for the communication between a computer and the master-board")
 SET(PROJECT_URL https://github.com/open-dynamic-robot-initiative/master-board)
 
+# --- OPTIONS ----------------------------------------
+OPTION(BUILD_PYTHON_INTERFACE "Build the python binding" OFF)
+OPTION(PYTHON_STANDARD_LAYOUT "Enable standard Python package layout" ON)
+OPTION(PYTHON_DEB_LAYOUT "Enable Debian-style Python package layout" ON)
+
 INCLUDE(cmake/base.cmake)
 INCLUDE(cmake/boost.cmake)
 INCLUDE(cmake/python.cmake)
@@ -25,9 +29,7 @@ INCLUDE(cmake/ide.cmake)
 
 COMPUTE_PROJECT_ARGS(PROJECT_ARGS LANGUAGES CXX)
 PROJECT(${PROJECT_NAME} ${PROJECT_ARGS})
-
-# --- OPTIONS ----------------------------------------
-OPTION (BUILD_PYTHON_INTERFACE "Build the python binding" OFF)
+CHECK_MINIMAL_CXX_STANDARD(11 ENFORCE)
 
 MACRO(TAG_LIBRARY_VERSION target)
   SET_TARGET_PROPERTIES(${target} PROPERTIES SOVERSION ${PROJECT_VERSION})
@@ -38,19 +40,11 @@ ENDMACRO(TAG_LIBRARY_VERSION)
 # ----------------------------------------------------
 
 # Set component to fetch from boost
-SET(BOOST_REQUIRED_COMPONENTS "")
-SET(BOOST_OPTIONAL_COMPONENTS "")
 # Get the python interface for the bindings
 IF(BUILD_PYTHON_INTERFACE)
-  SET(BOOST_REQUIRED_COMPONENTS ${BOOST_REQUIRED_COMPONENTS} python)
   FINDPYTHON()
-  INCLUDE_DIRECTORIES(SYSTEM ${PYTHON_INCLUDE_DIRS})
+  SEARCH_FOR_BOOST_PYTHON(REQUIRED)
 ENDIF(BUILD_PYTHON_INTERFACE)
-# Search for the boost libraries
-SET(BOOST_COMPONENTS ${BOOST_REQUIRED_COMPONENTS} ${BOOST_OPTIONAL_COMPONENTS} ${BOOST_BUILD_COMPONENTS})
-SEARCH_FOR_BOOST()
-# Path to boost headers
-INCLUDE_DIRECTORIES(SYSTEM ${Boost_INCLUDE_DIRS})
 
 # ----------------------------------------------------
 # --- INCLUDE ----------------------------------------
@@ -101,8 +95,10 @@ IF(BUILD_PYTHON_INTERFACE)
   ADD_HEADER_GROUP(${PYWRAP}_HEADERS)
   ADD_SOURCE_GROUP(${PYWRAP}_SOURCES)
 
+  TARGET_INCLUDE_DIRECTORIES(${PYWRAP} SYSTEM PRIVATE ${PYTHON_INCLUDE_DIR})
   TARGET_LINK_LIBRARIES(${PYWRAP} ${PROJECT_NAME})
   TARGET_LINK_BOOST_PYTHON(${PYWRAP})
+  SET_TARGET_PROPERTIES(${PYWRAP} PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 
   INSTALL(TARGETS ${PYWRAP} DESTINATION ${${PYWRAP}_INSTALL_DIR})
   # --- PACKAGING --- #

--- a/sdk/master_board_sdk/include/master_board_sdk/motor_driver.h
+++ b/sdk/master_board_sdk/include/master_board_sdk/motor_driver.h
@@ -13,8 +13,8 @@ public:
 	void SetMotors(Motor *motor1, Motor *motor2);
 	void Print();
 	void EnablePositionRolloverError();
-  	void DisablePositionRolloverError();
-  	void SetTimeout(uint8_t time);
+  void DisablePositionRolloverError();
+  void SetTimeout(uint8_t time);
 
 	bool IsConnected();
 	bool IsEnabled();
@@ -41,7 +41,7 @@ public:
 	uint8_t timeout;
 
 	// Set functions for Python binding with Boost
-  	void set_motor1(Motor* mot) { this->motor1 = mot; };
+  void set_motor1(Motor* mot) { this->motor1 = mot; };
 	void set_motor2(Motor* mot) { this->motor2 = mot; };
 	void set_is_connected(bool val) { this->is_connected = val; };
 	void set_is_enabled(bool val) { this->is_enabled = val; };
@@ -52,7 +52,7 @@ public:
 	void set_adc(float adc_val []); // See definition in .cpp
 
 	// Get functions for Python binding with Boost
-  	Motor* get_motor1() { return (this->motor1); };
+  Motor* get_motor1() { return (this->motor1); };
 	Motor* get_motor2() { return (this->motor2); };
 	bool get_is_connected() { return this->is_connected; };
 	bool get_is_enabled() { return this->is_enabled; };

--- a/sdk/master_board_sdk/include/master_board_sdk/protocol.h
+++ b/sdk/master_board_sdk/include/master_board_sdk/protocol.h
@@ -42,8 +42,8 @@
 #define UD_QN_ISAT 3
 #define UD_QN_CR   15
 #define UD_QN_ADC  16
-#define UD_QN_KP   16
-#define UD_QN_KD   16
+#define UD_QN_KP   9
+#define UD_QN_KD   9
 
 #define IMU_QN_ACC 11
 #define IMU_QN_GYR 11

--- a/sdk/master_board_sdk/include/master_board_sdk/protocol.h
+++ b/sdk/master_board_sdk/include/master_board_sdk/protocol.h
@@ -42,8 +42,8 @@
 #define UD_QN_ISAT 3
 #define UD_QN_CR   15
 #define UD_QN_ADC  16
-#define UD_QN_KP   9
-#define UD_QN_KD   9
+#define UD_QN_KP   11
+#define UD_QN_KD   10
 
 #define IMU_QN_ACC 11
 #define IMU_QN_GYR 11

--- a/sdk/master_board_sdk/src/master_board_interface.cpp
+++ b/sdk/master_board_sdk/src/master_board_interface.cpp
@@ -194,10 +194,10 @@ int MasterBoardInterface::SendCommand()
     command_packet.dual_motor_driver_command_packets[i].velocity_ref[1] = FLOAT_TO_D16QN(motor_drivers[i].motor2->velocity_ref * 60. / (2. * M_PI * 1000.), UD_QN_VEL);
     command_packet.dual_motor_driver_command_packets[i].current_ref[0] = FLOAT_TO_D16QN(motor_drivers[i].motor1->current_ref, UD_QN_IQ);
     command_packet.dual_motor_driver_command_packets[i].current_ref[1] = FLOAT_TO_D16QN(motor_drivers[i].motor2->current_ref, UD_QN_IQ);
-    command_packet.dual_motor_driver_command_packets[i].kp[0] = FLOAT_TO_D16QN(2. * M_PI * motor_drivers[i].motor1->kp, UD_QN_ISAT);
-    command_packet.dual_motor_driver_command_packets[i].kp[1] = FLOAT_TO_D16QN(2. * M_PI * motor_drivers[i].motor2->kp, UD_QN_ISAT);
-    command_packet.dual_motor_driver_command_packets[i].kd[0] = FLOAT_TO_D16QN(2. * M_PI * 1000. / 60. * motor_drivers[i].motor1->kd, UD_QN_ISAT);
-    command_packet.dual_motor_driver_command_packets[i].kd[1] = FLOAT_TO_D16QN(2. * M_PI * 1000. / 60. * motor_drivers[i].motor2->kd, UD_QN_ISAT);
+    command_packet.dual_motor_driver_command_packets[i].kp[0] = FLOAT_TO_D16QN(2. * M_PI * motor_drivers[i].motor1->kp, UD_QN_KP);
+    command_packet.dual_motor_driver_command_packets[i].kp[1] = FLOAT_TO_D16QN(2. * M_PI * motor_drivers[i].motor2->kp, UD_QN_KP);
+    command_packet.dual_motor_driver_command_packets[i].kd[0] = FLOAT_TO_D16QN(2. * M_PI * 1000. / 60. * motor_drivers[i].motor1->kd, UD_QN_KD);
+    command_packet.dual_motor_driver_command_packets[i].kd[1] = FLOAT_TO_D16QN(2. * M_PI * 1000. / 60. * motor_drivers[i].motor2->kd, UD_QN_KD);
   }
 
   // Current time point

--- a/sdk/master_board_sdk/src/master_board_interface.cpp
+++ b/sdk/master_board_sdk/src/master_board_interface.cpp
@@ -188,16 +188,16 @@ int MasterBoardInterface::SendCommand()
     }
     mode |= UD_COMMAND_MODE_TIMEOUT & motor_drivers[i].timeout;
     command_packet.dual_motor_driver_command_packets[i].mode = mode;
-    command_packet.dual_motor_driver_command_packets[i].position_ref[0] = FLOAT_TO_D16QN(motor_drivers[i].motor1->position_ref / (2. * M_PI), UD_QN_POS) - motor_drivers[i].motor1->position_offset;
-    command_packet.dual_motor_driver_command_packets[i].position_ref[1] = FLOAT_TO_D16QN(motor_drivers[i].motor2->position_ref / (2. * M_PI), UD_QN_POS) - motor_drivers[i].motor2->position_offset;
+    command_packet.dual_motor_driver_command_packets[i].position_ref[0] = FLOAT_TO_D32QN((motor_drivers[i].motor1->position_ref - motor_drivers[i].motor1->position_offset)/ (2. * M_PI) , UD_QN_POS) ;
+    command_packet.dual_motor_driver_command_packets[i].position_ref[1] = FLOAT_TO_D32QN((motor_drivers[i].motor2->position_ref - motor_drivers[i].motor2->position_offset)/ (2. * M_PI) , UD_QN_POS) ;
     command_packet.dual_motor_driver_command_packets[i].velocity_ref[0] = FLOAT_TO_D16QN(motor_drivers[i].motor1->velocity_ref * 60. / (2. * M_PI * 1000.), UD_QN_VEL);
     command_packet.dual_motor_driver_command_packets[i].velocity_ref[1] = FLOAT_TO_D16QN(motor_drivers[i].motor2->velocity_ref * 60. / (2. * M_PI * 1000.), UD_QN_VEL);
     command_packet.dual_motor_driver_command_packets[i].current_ref[0] = FLOAT_TO_D16QN(motor_drivers[i].motor1->current_ref, UD_QN_IQ);
     command_packet.dual_motor_driver_command_packets[i].current_ref[1] = FLOAT_TO_D16QN(motor_drivers[i].motor2->current_ref, UD_QN_IQ);
     command_packet.dual_motor_driver_command_packets[i].kp[0] = FLOAT_TO_D16QN(2. * M_PI * motor_drivers[i].motor1->kp, UD_QN_KP);
     command_packet.dual_motor_driver_command_packets[i].kp[1] = FLOAT_TO_D16QN(2. * M_PI * motor_drivers[i].motor2->kp, UD_QN_KP);
-    command_packet.dual_motor_driver_command_packets[i].kd[0] = FLOAT_TO_D16QN(2. * M_PI * 1000. / 60. * motor_drivers[i].motor1->kd, UD_QN_KD);
-    command_packet.dual_motor_driver_command_packets[i].kd[1] = FLOAT_TO_D16QN(2. * M_PI * 1000. / 60. * motor_drivers[i].motor2->kd, UD_QN_KD);
+    command_packet.dual_motor_driver_command_packets[i].kd[0] = FLOAT_TO_D16QN(((2. * M_PI * 1000.)/60.0) * motor_drivers[i].motor1->kd, UD_QN_KD);
+    command_packet.dual_motor_driver_command_packets[i].kd[1] = FLOAT_TO_D16QN(((2. * M_PI * 1000.)/60.0) * motor_drivers[i].motor2->kd, UD_QN_KD);
   }
 
   // Current time point


### PR DESCRIPTION
- Add local joint impedance control interface to close the impedance loop on the motor driver.
 To be used the user needs to send Kp, Kd, pos_ref and vel_ref. 
`iq = iq_ff + Kp (pos_ref - pos) + Kd*vel_ref-vel`
Note that pure direct current is also possible by setting Kp=0 Kd=0

To use this feature, you must first reflash your motor driver(uDriver) with the latest version of the firmware (to come).

- Small refactoring of the packaging to improve the linkage of the python bindings.