### PR TITLE
[SDK] Add support for current saturation

### DIFF
--- a/sdk/master_board_sdk/CMakeLists.txt
+++ b/sdk/master_board_sdk/CMakeLists.txt
@@ -141,6 +141,10 @@ ADD_EXECUTABLE(master-board-example example/example.cpp)
 TARGET_LINK_LIBRARIES(master-board-example ${PROJECT_NAME})
 INSTALL(TARGETS master-board-example DESTINATION bin)
 
+ADD_EXECUTABLE(master-board-example-pd example/example_pd.cpp)
+TARGET_LINK_LIBRARIES(master-board-example-pd ${PROJECT_NAME})
+INSTALL(TARGETS master-board-example-pd DESTINATION bin)
+
 # --- PACKAGING ----------------------------------------------------------------
 PKG_CONFIG_APPEND_LIBS (${PROJECT_NAME})
 PKG_CONFIG_APPEND_BOOST_LIBS(${BOOST_REQUIRED_COMPONENTS})

--- a/sdk/master_board_sdk/Makefile
+++ b/sdk/master_board_sdk/Makefile
@@ -17,8 +17,11 @@ app: example.o ESPNOW_manager.o ESPNOW_types.o Link_manager.o ETHERNET_types.o m
 	mkdir -p bin
 	$(CC) $(CFLAGS) -o bin/example $(addprefix build/,$^) -pthread
 
+app_pd: example_pd.o ESPNOW_manager.o ESPNOW_types.o Link_manager.o ETHERNET_types.o master_board_interface.o motor.o motor_driver.o
+	mkdir -p bin
+	$(CC) $(CFLAGS) -o bin/example_pd $(addprefix build/,$^) -pthread
 
-all: clear clean app
+all: clear clean app app_pd
 
 clean: 
 	#$(RM) build/*

--- a/sdk/master_board_sdk/example/example_pd.cpp
+++ b/sdk/master_board_sdk/example/example_pd.cpp
@@ -1,0 +1,147 @@
+#include <assert.h>
+#include <unistd.h>
+#include <chrono>
+#include <math.h>
+#include <stdio.h>
+#include <sys/stat.h>
+
+#include "master_board_sdk/master_board_interface.h"
+#include "master_board_sdk/defines.h"
+
+#define N_SLAVES_CONTROLED 6
+
+int main(int argc, char **argv)
+{
+	int cpt = 0;
+	double dt = 0.001;
+	double t = 0;
+	double kp = 5.;
+	double kd = 0.1;
+	double iq_sat = 4.0;
+	double freq = 0.5;
+	double amplitude = M_PI;
+	double init_pos[N_SLAVES * 2] = {0};
+	int state = 0;
+
+	nice(-20); //give the process a high priority
+	printf("-- Main --\n");
+	//assert(argc > 1);
+	MasterBoardInterface robot_if(argv[1]);
+	robot_if.Init();
+	//Initialisation, send the init commands
+	for (int i = 0; i < N_SLAVES_CONTROLED; i++)
+	{
+		robot_if.motor_drivers[i].motor1->SetCurrentReference(0);
+		robot_if.motor_drivers[i].motor2->SetCurrentReference(0);
+		robot_if.motor_drivers[i].motor1->Enable();
+		robot_if.motor_drivers[i].motor2->Enable();
+		
+		// Set the gains for the PD controller running on the cards.
+		robot_if.motor_drivers[i].motor1->set_kp(kp);
+		robot_if.motor_drivers[i].motor2->set_kp(kp);
+		robot_if.motor_drivers[i].motor1->set_kd(kd);
+		robot_if.motor_drivers[i].motor2->set_kd(kd);
+
+		// Set the maximum current controlled by the card.
+		robot_if.motor_drivers[i].motor1->set_current_sat(iq_sat);
+		robot_if.motor_drivers[i].motor2->set_current_sat(iq_sat);
+		
+		robot_if.motor_drivers[i].EnablePositionRolloverError();
+		robot_if.motor_drivers[i].SetTimeout(5);
+		robot_if.motor_drivers[i].Enable();
+	}
+
+	std::chrono::time_point<std::chrono::system_clock> last = std::chrono::system_clock::now();
+	while (!robot_if.IsTimeout() && !robot_if.IsAckMsgReceived()) {
+		if (((std::chrono::duration<double>)(std::chrono::system_clock::now() - last)).count() > dt)
+		{
+			last = std::chrono::system_clock::now();
+			robot_if.SendInit();
+		}
+	}
+
+	if (robot_if.IsTimeout())
+	{
+		printf("Timeout while waiting for ack.\n");
+	}
+
+	while (!robot_if.IsTimeout())
+	{
+		if (((std::chrono::duration<double>)(std::chrono::system_clock::now() - last)).count() > dt)
+		{
+			last = std::chrono::system_clock::now(); //last+dt would be better
+			cpt++;
+			t += dt;
+			robot_if.ParseSensorData(); // This will read the last incomming packet and update all sensor fields.
+			switch (state)
+			{
+			case 0: //check the end of calibration (are the all controlled motor enabled and ready?)
+				state = 1;
+				for (int i = 0; i < N_SLAVES_CONTROLED * 2; i++)
+				{
+					if (!robot_if.motor_drivers[i / 2].is_connected) continue; // ignoring the motors of a disconnected slave
+
+					if (!(robot_if.motors[i].IsEnabled() && robot_if.motors[i].IsReady()))
+					{
+						state = 0;
+					}
+					init_pos[i] = robot_if.motors[i].GetPosition(); //initial position
+
+					// Use the current state as target for the PD controller.
+					robot_if.motors[i].SetCurrentReference(0.);
+					robot_if.motors[i].SetPositionReference(init_pos[i]);
+					robot_if.motors[i].SetVelocityReference(0.);
+
+					t = 0;	//to start sin at 0
+				}
+				break;
+			case 1:
+				//closed loop, position
+				for (int i = 0; i < N_SLAVES_CONTROLED * 2; i++)
+				{
+					if (i % 2 == 0)
+					{
+						if (!robot_if.motor_drivers[i / 2].is_connected) continue; // ignoring the motors of a disconnected slave
+ 
+						// making sure that the transaction with the corresponding µdriver board succeeded
+						if (robot_if.motor_drivers[i / 2].error_code == 0xf)
+						{
+							//printf("Transaction with SPI%d failed\n", i / 2);
+							continue; //user should decide what to do in that case, here we ignore that motor
+						}
+					}
+
+					if (robot_if.motors[i].IsEnabled())
+					{
+						double ref = init_pos[i] + amplitude * sin(2 * M_PI * freq * t);
+						double v_ref = 2. * M_PI * freq * amplitude * cos(2 * M_PI * freq * t);
+
+						robot_if.motors[i].SetCurrentReference(0.);
+						robot_if.motors[i].SetPositionReference(ref);
+						robot_if.motors[i].SetVelocityReference(v_ref);
+					}
+				}
+				break;
+			}
+			if (cpt % 100 == 0)
+			{
+				printf("\33[H\33[2J"); //clear screen
+				robot_if.PrintIMU();
+				robot_if.PrintADC();
+				robot_if.PrintMotors();
+				robot_if.PrintMotorDrivers();
+				robot_if.PrintStats();
+				fflush(stdout);
+				 
+
+			}
+			robot_if.SendCommand(); //This will send the command packet
+		}
+		else
+		{
+			std::this_thread::yield();
+		}
+	}
+        printf("Masterboard timeout detected. Either the masterboard has been shut down or there has been a connection issue with the cable/wifi.\n");
+	return 0;
+}

--- a/sdk/master_board_sdk/include/master_board_sdk/motor.h
+++ b/sdk/master_board_sdk/include/master_board_sdk/motor.h
@@ -42,6 +42,7 @@ public:
   float position_ref;  // [rad]
   float velocity_ref;  // [rad/s]
   float current_ref;   // [A]
+  float current_sat;   // [A]
   float kp;            // [A/rad]
   float kd;            // [As/rad]
 
@@ -64,6 +65,7 @@ public:
   void set_position_ref(float val) { this->position_ref = val; };
   void set_velocity_ref(float val) { this->velocity_ref = val; };
   void set_current_ref(float val) { this->current_ref = val; };
+  void set_current_sat(float val) { this->current_sat = val; };
   void set_kp(float val) { this->kp = val; };
   void set_kd(float val) { this->kd = val; };
   void set_enable(bool val) { this->enable = val; };
@@ -83,6 +85,7 @@ public:
   float get_position_ref() { return this->position_ref; };
   float get_velocity_ref() { return this->velocity_ref; };
   float get_current_ref() { return this->current_ref; };
+  float get_current_sat() { return this->current_sat; };
   float get_kp() { return this->kp; };
   float get_kd() { return this->kd; };
   bool get_enable() { return this->enable; };

--- a/sdk/master_board_sdk/include/master_board_sdk/protocol.h
+++ b/sdk/master_board_sdk/include/master_board_sdk/protocol.h
@@ -129,11 +129,11 @@
 
 #define FLOAT_TO_uD32QN(a,n)      ((uint32_t) ((a) * (1<<(n))))
 #define FLOAT_TO_uD16QN(a,n)      ((uint16_t) ((a) * (1<<(n))))
-#define FLOAT_TO_uD8QN (a,n)      ((uint8_t)  ((a) * (1<<(n))))
+#define FLOAT_TO_uD8QN(a,n)       ((uint8_t)  ((a) * (1<<(n))))
 
 #define FLOAT_TO_D32QN(a,n)       ((int32_t) ((a) * (1<<(n))))
 #define FLOAT_TO_D16QN(a,n)       ((int16_t) ((a) * (1<<(n))))
-#define FLOAT_TO_D8QN (a,n)       ((int8_t)  ((a) * (1<<(n))))
+#define FLOAT_TO_D8QN(a,n)        ((int8_t)  ((a) * (1<<(n))))
 
 
 #endif

--- a/sdk/master_board_sdk/src/master_board_interface.cpp
+++ b/sdk/master_board_sdk/src/master_board_interface.cpp
@@ -198,6 +198,8 @@ int MasterBoardInterface::SendCommand()
     command_packet.dual_motor_driver_command_packets[i].kp[1] = FLOAT_TO_D16QN(2. * M_PI * motor_drivers[i].motor2->kp, UD_QN_KP);
     command_packet.dual_motor_driver_command_packets[i].kd[0] = FLOAT_TO_D16QN(((2. * M_PI * 1000.)/60.0) * motor_drivers[i].motor1->kd, UD_QN_KD);
     command_packet.dual_motor_driver_command_packets[i].kd[1] = FLOAT_TO_D16QN(((2. * M_PI * 1000.)/60.0) * motor_drivers[i].motor2->kd, UD_QN_KD);
+    command_packet.dual_motor_driver_command_packets[i].i_sat[0] = FLOAT_TO_uD8QN(motor_drivers[i].motor1->current_sat, UD_QN_ISAT);
+    command_packet.dual_motor_driver_command_packets[i].i_sat[1] = FLOAT_TO_uD8QN(motor_drivers[i].motor2->current_sat, UD_QN_ISAT);
   }
 
   // Current time point


### PR DESCRIPTION
Add support for sending motor current limits to the boards.

This PR also adds a copy of the `example.cpp` called `example.cpp`. The example is the same but uses the PD controller on the card + the current limitation on the card.