### PR TITLE
SDK: Fix bug/crash with overflow in statistic computation

### DIFF
--- a/sdk/master_board_sdk/src/master_board_interface.cpp
+++ b/sdk/master_board_sdk/src/master_board_interface.cpp
@@ -292,8 +292,8 @@ void MasterBoardInterface::callback(uint8_t src_mac[6], uint8_t *data, int len)
       last_cmd_packet_loss = packet_recv->packet_loss;
     }
 
-    //Sensor_loss
-    if (packet_recv->sensor_index - last_sensor_index - 1 != 0)
+    //Sensor_loss. Ignore case where packet_recv->sensor_index is overflowing.
+    if (packet_recv->sensor_index - last_sensor_index - 1 > 0)
     {
       if ((packet_recv->sensor_index - last_sensor_index - 2) >= MAX_HIST)
       {


### PR DESCRIPTION
We ran into a problem when running the master-board SDK for longer than 1 minute. 

As it turns out, the `uint_16` field `packet_recv->sensor_index` is overflowing and starting to count again from zero. This caused the `if` statement we modified below to get evaluated to `true` (as the last package was > 65000). Eventually, it tried to update the history at 

```
histogram_lost_sensor_packets[packet_recv->sensor_index - last_sensor_index - 2]++
```

but the computed address causes a segfault as it is negative.

The fix is a bit conservative. We basically assume that the difference should be always positive. If that's not the case, we are overflowing. This fix is simple but we miss the edge case when overflowing (which we though is fine, as it's happening only once every minute and losing the statistic for this rare evening might be okay compared to more complex code to maintain).

\cc @jviereck 