### PR TITLE
Add parse sensor data

### DIFF
--- a/sdk/master_board_sdk/src/master_board_interface.cpp
+++ b/sdk/master_board_sdk/src/master_board_interface.cpp
@@ -76,7 +76,7 @@ int MasterBoardInterface::Init()
   {
     return -1;
   }
-  ParseSensorData();
+  ParseSensorData(); // Parse sensor data to initialize the variables of the masterboard interface
   signal(SIGINT, KeyboardStop);
   return 0;
 }

--- a/sdk/master_board_sdk/src/master_board_interface.cpp
+++ b/sdk/master_board_sdk/src/master_board_interface.cpp
@@ -76,6 +76,7 @@ int MasterBoardInterface::Init()
   {
     return -1;
   }
+  ParseSensorData();
   signal(SIGINT, KeyboardStop);
   return 0;
 }


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."

When using a fast computer, checks inside `HasError` can be made before any packet has been received because the code runs too fast. As a result, values returned by the interface are still in their initial undefined state. This results in motor positions being infinite which triggers a position limit error or the error_code of the driver not being defined which triggers driver error security (error code equal to `208863232` for instance).

A call to `ParseSensorData` has been added at the end of the initialization function of the MasterBoardInterface. It initializes the interface values, either to 0 if no packet has been received yet or to decoded values if a packet has been received. That way if the code runs too fast all values will be 0 instead of infinite or random.

## How I Tested

I ran a calibration procedure both in C++ and in Python by using the bindings. The calibration was successful in both cases and without error messages.  

[//]: # "Explain how you tested your changes"

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
