### PR TITLE
fix "cannot bind packed field" on Ubuntu 20.04

### DIFF
--- a/sdk/master_board_sdk/src/master_board_interface.cpp
+++ b/sdk/master_board_sdk/src/master_board_interface.cpp
@@ -361,9 +361,9 @@ void MasterBoardInterface::ParseSensorData()
     // zero. Check for this small velocity and set the velocity to zero.
     // See also: https://github.com/open-dynamic-robot-initiative/master-board/issues/92
     for (int j = 0; j < 2; j++) {
-      int16_t &velocity = sensor_packet.dual_motor_driver_sensor_packets[i].velocity[j];
+      int16_t velocity = sensor_packet.dual_motor_driver_sensor_packets[i].velocity[j];
       if (velocity == 1 || velocity == -1) {
-        velocity = 0;
+        sensor_packet.dual_motor_driver_sensor_packets[i].velocity[j] = 0;
       }
     }
 


### PR DESCRIPTION

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

While the old version is building on Ubuntu 18.04, newer versions of gcc
do not allow the assignment to reference here.

Note that this PR goes to mnaveau/communication_benchmark as on master this has already been fixed.


## How I Tested

Build using an Ubuntu 20.04 image.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
