### PR TITLE
Use ip instead of ifconfig

### DIFF
--- a/sdk/scripts/setup_wifi.sh
+++ b/sdk/scripts/setup_wifi.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -x #echo on
 
-sudo ifconfig $1 down
+sudo ip link set down $1
 sudo iwconfig $1 mode monitor
-sudo ifconfig $1 up
+sudo ip link set up $1
 sudo iwconfig $1 channel $2
 


### PR DESCRIPTION

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

`ifconfig` is deprecated on newer versions of Ubuntu, `ip` should be
used instead (which is installed by default, while `ifconfig` is not).



## How I Tested

By running it.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
