### PR TITLE
Handle out-of-range motor params without wraparound

### DIFF
--- a/sdk/master_board_sdk/Makefile
+++ b/sdk/master_board_sdk/Makefile
@@ -13,6 +13,10 @@ default: all
 	mkdir -p build
 	$(CC) $(CFLAGS) $(INCLUDES) -o build/$@ -c $^
 
+%.o: tests/%.cpp
+	mkdir -p build
+	$(CC) $(CFLAGS) $(INCLUDES) $(shell pkg-config --cflags catch2) -std=c++17 -o build/$@ -c $^
+
 app: example.o ESPNOW_manager.o ESPNOW_types.o Link_manager.o ETHERNET_types.o master_board_interface.o motor.o motor_driver.o
 	mkdir -p bin
 	$(CC) $(CFLAGS) -o bin/example $(addprefix build/,$^) -pthread
@@ -20,6 +24,10 @@ app: example.o ESPNOW_manager.o ESPNOW_types.o Link_manager.o ETHERNET_types.o m
 app_pd: example_pd.o ESPNOW_manager.o ESPNOW_types.o Link_manager.o ETHERNET_types.o master_board_interface.o motor.o motor_driver.o
 	mkdir -p bin
 	$(CC) $(CFLAGS) -o bin/example_pd $(addprefix build/,$^) -pthread
+
+tests: test_protocol.o
+	mkdir -p bin
+	$(CC) $(CFLAGS) -o bin/tests $(addprefix build/,$^) $(shell pkg-config --libs catch2) -lCatch2Main -pthread
 
 all: clear clean app app_pd
 

--- a/sdk/master_board_sdk/Makefile
+++ b/sdk/master_board_sdk/Makefile
@@ -15,6 +15,7 @@ default: all
 
 %.o: tests/%.cpp
 	mkdir -p build
+	pkg-config --atleast-version=3.1 catch2
 	$(CC) $(CFLAGS) $(INCLUDES) $(shell pkg-config --cflags catch2) -std=c++17 -o build/$@ -c $^
 
 app: example.o ESPNOW_manager.o ESPNOW_types.o Link_manager.o ETHERNET_types.o master_board_interface.o motor.o motor_driver.o

--- a/sdk/master_board_sdk/Makefile
+++ b/sdk/master_board_sdk/Makefile
@@ -25,9 +25,12 @@ app_pd: example_pd.o ESPNOW_manager.o ESPNOW_types.o Link_manager.o ETHERNET_typ
 	mkdir -p bin
 	$(CC) $(CFLAGS) -o bin/example_pd $(addprefix build/,$^) -pthread
 
-tests: test_protocol.o
+sdk_tests: test_protocol.o
 	mkdir -p bin
-	$(CC) $(CFLAGS) -o bin/tests $(addprefix build/,$^) $(shell pkg-config --libs catch2) -lCatch2Main -pthread
+	$(CC) $(CFLAGS) -o bin/sdk_tests $(addprefix build/,$^) $(shell pkg-config --libs catch2) -lCatch2Main -pthread
+
+test : sdk_tests
+	bin/sdk_tests
 
 all: clear clean app app_pd
 

--- a/sdk/master_board_sdk/include/master_board_sdk/protocol.h
+++ b/sdk/master_board_sdk/include/master_board_sdk/protocol.h
@@ -104,6 +104,8 @@
 #define UD_SENSOR_STATUS_ERROR_ENCODER2 6
 //! \brief Some other error
 #define UD_SENSOR_STATUS_ERROR_OTHER 7
+//! \brief CRC error in the SPI transaction
+#define UD_SENSOR_STATUS_CRC_ERROR 15
 //! \brief UD packets length in word (16 bits)
 #define UD_LENGTH 14
 

--- a/sdk/master_board_sdk/include/master_board_sdk/protocol.h
+++ b/sdk/master_board_sdk/include/master_board_sdk/protocol.h
@@ -104,8 +104,6 @@
 #define UD_SENSOR_STATUS_ERROR_ENCODER2 6
 //! \brief Some other error
 #define UD_SENSOR_STATUS_ERROR_OTHER 7
-//! \brief CRC error in the SPI transaction
-#define UD_SENSOR_STATUS_CRC_ERROR 15
 //! \brief UD packets length in word (16 bits)
 #define UD_LENGTH 14
 

--- a/sdk/master_board_sdk/include/master_board_sdk/protocol.h
+++ b/sdk/master_board_sdk/include/master_board_sdk/protocol.h
@@ -129,13 +129,13 @@
 #define D16QN_TO_FLOAT(a,n)       ((float)(a)) / (1<<(n))
 #define D8QN_TO_FLOAT(a,n)        ((float)(a)) / (1<<(n))
 
-#define FLOAT_TO_uD32QN(a,n)      ((uint32_t) ((a) * (1<<(n))))
-#define FLOAT_TO_uD16QN(a,n)      ((uint16_t) ((a) * (1<<(n))))
-#define FLOAT_TO_uD8QN(a,n)       ((uint8_t)  ((a) * (1<<(n))))
+#define FLOAT_TO_uD32QN(a,n)      ((uint32_t) min(max(((a) * (1<<(n))), 0.0), 4294967295.0))
+#define FLOAT_TO_uD16QN(a,n)      ((uint16_t) min(max(((a) * (1<<(n))), 0.0), 65535.0))
+#define FLOAT_TO_uD8QN(a,n)       ((uint8_t)  min(max(((a) * (1<<(n))), 0.0), 255.0))
 
-#define FLOAT_TO_D32QN(a,n)       ((int32_t) ((a) * (1<<(n))))
-#define FLOAT_TO_D16QN(a,n)       ((int16_t) ((a) * (1<<(n))))
-#define FLOAT_TO_D8QN(a,n)        ((int8_t)  ((a) * (1<<(n))))
+#define FLOAT_TO_D32QN(a,n)       ((int32_t) min(max(((a) * (1<<(n))), -2147483645.0), 2147483645.0))
+#define FLOAT_TO_D16QN(a,n)       ((int16_t) min(max((a) * (1<<(n)), -32765.0), 32765.0))
+#define FLOAT_TO_D8QN(a,n)        ((int8_t)  min(max(((a) * (1<<(n))), -127.0, +127.0)))
 
 
 #endif

--- a/sdk/master_board_sdk/include/master_board_sdk/protocol.h
+++ b/sdk/master_board_sdk/include/master_board_sdk/protocol.h
@@ -129,13 +129,13 @@
 #define D16QN_TO_FLOAT(a,n)       ((float)(a)) / (1<<(n))
 #define D8QN_TO_FLOAT(a,n)        ((float)(a)) / (1<<(n))
 
-#define FLOAT_TO_uD32QN(a,n)      ((uint32_t) min(max(((a) * (1<<(n))), 0.0), 4294967295.0))
-#define FLOAT_TO_uD16QN(a,n)      ((uint16_t) min(max(((a) * (1<<(n))), 0.0), 65535.0))
-#define FLOAT_TO_uD8QN(a,n)       ((uint8_t)  min(max(((a) * (1<<(n))), 0.0), 255.0))
+#define FLOAT_TO_uD32QN(a,n)      ((uint32_t) std::min(std::max(((a) * (1<<(n))), 0.0), 4294967295.0))
+#define FLOAT_TO_uD16QN(a,n)      ((uint16_t) std::min(std::max(((a) * (1<<(n))), 0.0), 65535.0))
+#define FLOAT_TO_uD8QN(a,n)       ((uint8_t)  std::min(std::max(((a) * (1<<(n))), 0.0), 255.0))
 
-#define FLOAT_TO_D32QN(a,n)       ((int32_t) min(max(((a) * (1<<(n))), -2147483645.0), 2147483645.0))
-#define FLOAT_TO_D16QN(a,n)       ((int16_t) min(max((a) * (1<<(n)), -32765.0), 32765.0))
-#define FLOAT_TO_D8QN(a,n)        ((int8_t)  min(max(((a) * (1<<(n))), -127.0, +127.0)))
+#define FLOAT_TO_D32QN(a,n)       ((int32_t) std::min(std::max(((a) * (1<<(n))), -2147483645.0), 2147483645.0))
+#define FLOAT_TO_D16QN(a,n)       ((int16_t) std::min(std::max((a) * (1<<(n)), -32765.0), 32765.0))
+#define FLOAT_TO_D8QN(a,n)        ((int8_t)  std::min(std::max(((a) * (1<<(n))), -127.0, +127.0)))
 
 
 #endif

--- a/sdk/master_board_sdk/include/master_board_sdk/protocol.h
+++ b/sdk/master_board_sdk/include/master_board_sdk/protocol.h
@@ -133,8 +133,8 @@
 #define FLOAT_TO_uD16QN(a,n)      ((uint16_t) std::min(std::max(((a) * (1<<(n))), 0.0), 65535.0))
 #define FLOAT_TO_uD8QN(a,n)       ((uint8_t)  std::min(std::max(((a) * (1<<(n))), 0.0), 255.0))
 
-#define FLOAT_TO_D32QN(a,n)       ((int32_t) std::min(std::max(((a) * (1<<(n))), -2147483645.0), 2147483645.0))
-#define FLOAT_TO_D16QN(a,n)       ((int16_t) std::min(std::max((a) * (1<<(n)), -32765.0), 32765.0))
+#define FLOAT_TO_D32QN(a,n)       ((int32_t) std::min(std::max(((a) * (1<<(n))), -2147483647.0), 2147483647.0))
+#define FLOAT_TO_D16QN(a,n)       ((int16_t) std::min(std::max((a) * (1<<(n)), -32767.0), 32767.0))
 #define FLOAT_TO_D8QN(a,n)        ((int8_t)  std::min(std::max(((a) * (1<<(n))), -127.0, +127.0)))
 
 

--- a/sdk/master_board_sdk/src/master_board_interface.cpp
+++ b/sdk/master_board_sdk/src/master_board_interface.cpp
@@ -195,10 +195,10 @@ int MasterBoardInterface::SendCommand()
     command_packet.dual_motor_driver_command_packets[i].velocity_ref[1] = FLOAT_TO_D16QN(motor_drivers[i].motor2->velocity_ref * 60. / (2. * M_PI * 1000.), UD_QN_VEL);
     command_packet.dual_motor_driver_command_packets[i].current_ref[0] = FLOAT_TO_D16QN(motor_drivers[i].motor1->current_ref, UD_QN_IQ);
     command_packet.dual_motor_driver_command_packets[i].current_ref[1] = FLOAT_TO_D16QN(motor_drivers[i].motor2->current_ref, UD_QN_IQ);
-    command_packet.dual_motor_driver_command_packets[i].kp[0] = FLOAT_TO_D16QN(2. * M_PI * motor_drivers[i].motor1->kp, UD_QN_KP);
-    command_packet.dual_motor_driver_command_packets[i].kp[1] = FLOAT_TO_D16QN(2. * M_PI * motor_drivers[i].motor2->kp, UD_QN_KP);
-    command_packet.dual_motor_driver_command_packets[i].kd[0] = FLOAT_TO_D16QN(((2. * M_PI * 1000.)/60.0) * motor_drivers[i].motor1->kd, UD_QN_KD);
-    command_packet.dual_motor_driver_command_packets[i].kd[1] = FLOAT_TO_D16QN(((2. * M_PI * 1000.)/60.0) * motor_drivers[i].motor2->kd, UD_QN_KD);
+    command_packet.dual_motor_driver_command_packets[i].kp[0] = FLOAT_TO_uD16QN(2. * M_PI * motor_drivers[i].motor1->kp, UD_QN_KP);
+    command_packet.dual_motor_driver_command_packets[i].kp[1] = FLOAT_TO_uD16QN(2. * M_PI * motor_drivers[i].motor2->kp, UD_QN_KP);
+    command_packet.dual_motor_driver_command_packets[i].kd[0] = FLOAT_TO_uD16QN(((2. * M_PI * 1000.)/60.0) * motor_drivers[i].motor1->kd, UD_QN_KD);
+    command_packet.dual_motor_driver_command_packets[i].kd[1] = FLOAT_TO_uD16QN(((2. * M_PI * 1000.)/60.0) * motor_drivers[i].motor2->kd, UD_QN_KD);
     command_packet.dual_motor_driver_command_packets[i].i_sat[0] = FLOAT_TO_uD8QN(motor_drivers[i].motor1->current_sat, UD_QN_ISAT);
     command_packet.dual_motor_driver_command_packets[i].i_sat[1] = FLOAT_TO_uD8QN(motor_drivers[i].motor2->current_sat, UD_QN_ISAT);
   }

--- a/sdk/master_board_sdk/tests/test_protocol.cpp
+++ b/sdk/master_board_sdk/tests/test_protocol.cpp
@@ -1,27 +1,48 @@
 #include "catch2/catch_all.hpp"
 #include "master_board_sdk/protocol.h"
+#include <limits>
 
-TEST_CASE("FLOAT_TO_D32QN and friends work", "[env][new]") {
+TEST_CASE("FLOAT_TO_D32QN and friends work", "[protocol]") {
+
+  // check normal values
+  CHECK(FLOAT_TO_D32QN(0.0, 24) == int32_t(0x00000000));
   CHECK(FLOAT_TO_D32QN(1.0, 24) == int32_t(0x01000000));
   CHECK(FLOAT_TO_D32QN(-1.0, 24) == int32_t(0xff000000));
-  CHECK(FLOAT_TO_D32QN(-150.0, 24) == int32_t(0x80000001));
-  CHECK(FLOAT_TO_D32QN(-1.0e99, 24) == int32_t(0x80000001));
+
+  // check clamping
   CHECK(FLOAT_TO_D32QN(150.0, 24) == int32_t(0x7fffffff));  
+  CHECK(FLOAT_TO_D32QN(-150.0, 24) == int32_t(0x80000001));
+
+  // check that crazy values don't overflow
+  CHECK(FLOAT_TO_D32QN(-1.0e99, 24) == int32_t(0x80000001));
   CHECK(FLOAT_TO_D32QN(1.0e99, 24) == int32_t(0x7fffffff));  
+  CHECK(FLOAT_TO_D32QN(std::numeric_limits<double>::infinity(), 24) == int32_t(0x7fffffff));  
+  CHECK(FLOAT_TO_D32QN(-std::numeric_limits<double>::infinity(), 24) == int32_t(0x80000001));
+
+  // Note: I'm not sure this behavior is guaranteed by every floating point system.
+  // 0 is a relatively benign outcome for sending a NaN, but it might be better to check for NaN
+  // and throw an exception in, say, Motor::SetPositionReference
+  CHECK(FLOAT_TO_D32QN(std::numeric_limits<double>::quiet_NaN(), 24) == int32_t(0));  
+
 
   CHECK(FLOAT_TO_D16QN(1.0, 10) == int16_t(0x0400));
   CHECK(FLOAT_TO_D16QN(-1.0, 10) == int16_t(0xfc00));
   CHECK(FLOAT_TO_D16QN(150.0, 10) == int16_t(0x7fff));  
   CHECK(FLOAT_TO_D16QN(-150.0, 10) == int16_t(0x8001));
   CHECK(FLOAT_TO_D16QN(1.0e99, 10) == int16_t(0x7fff));  
+  CHECK(FLOAT_TO_D16QN(-1.0e99, 10) == int16_t(0x8001));
 
   CHECK(FLOAT_TO_uD16QN(1.0, 10) == uint16_t(0x0400));
   CHECK(FLOAT_TO_uD16QN(-1.0, 10) == uint16_t(0x0000));
   CHECK(FLOAT_TO_uD16QN(150.0, 10) == uint16_t(0xffff));  
+  CHECK(FLOAT_TO_uD16QN(-150.0, 10) == uint16_t(0x0000));  
   CHECK(FLOAT_TO_uD16QN(1.0e99, 10) == uint16_t(0xffff));  
+  CHECK(FLOAT_TO_uD16QN(-1.0e99, 10) == uint16_t(0x0000));  
 
   CHECK(FLOAT_TO_uD8QN(1.0, 3) == uint8_t(0x08));
   CHECK(FLOAT_TO_uD8QN(-1.0, 10) == uint8_t(0x00));
   CHECK(FLOAT_TO_uD8QN(150.0, 10) == uint8_t(0xff));  
+  CHECK(FLOAT_TO_uD8QN(-150.0, 10) == uint8_t(0x00));  
   CHECK(FLOAT_TO_uD8QN(1.0e99, 10) == uint8_t(0xff));  
+  CHECK(FLOAT_TO_uD8QN(-1.0e99, 10) == uint8_t(0x00));  
 }

--- a/sdk/master_board_sdk/tests/test_protocol.cpp
+++ b/sdk/master_board_sdk/tests/test_protocol.cpp
@@ -16,13 +16,16 @@ TEST_CASE("FLOAT_TO_D32QN and friends work", "[protocol]") {
   // check that crazy values don't overflow
   CHECK(FLOAT_TO_D32QN(-1.0e99, 24) == int32_t(0x80000001));
   CHECK(FLOAT_TO_D32QN(1.0e99, 24) == int32_t(0x7fffffff));  
-  CHECK(FLOAT_TO_D32QN(std::numeric_limits<double>::infinity(), 24) == int32_t(0x7fffffff));  
-  CHECK(FLOAT_TO_D32QN(-std::numeric_limits<double>::infinity(), 24) == int32_t(0x80000001));
+  CHECK(FLOAT_TO_D32QN(std::numeric_limits<double>::infinity(), 24) == 
+        int32_t(0x7fffffff));  
+  CHECK(FLOAT_TO_D32QN(-std::numeric_limits<double>::infinity(), 24) ==
+        int32_t(0x80000001));
 
   // Note: I'm not sure this behavior is guaranteed by every floating point system.
   // 0 is a relatively benign outcome for sending a NaN, but it might be better to check for NaN
   // and throw an exception in, say, Motor::SetPositionReference
-  CHECK(FLOAT_TO_D32QN(std::numeric_limits<double>::quiet_NaN(), 24) == int32_t(0));  
+  CHECK(FLOAT_TO_D32QN(std::numeric_limits<double>::quiet_NaN(), 24) ==
+        int32_t(0));  
 
 
   CHECK(FLOAT_TO_D16QN(1.0, 10) == int16_t(0x0400));

--- a/sdk/master_board_sdk/tests/test_protocol.cpp
+++ b/sdk/master_board_sdk/tests/test_protocol.cpp
@@ -1,0 +1,27 @@
+#include "catch2/catch_all.hpp"
+#include "master_board_sdk/protocol.h"
+
+TEST_CASE("FLOAT_TO_D32QN and friends work", "[env][new]") {
+  CHECK(FLOAT_TO_D32QN(1.0, 24) == int32_t(0x01000000));
+  CHECK(FLOAT_TO_D32QN(-1.0, 24) == int32_t(0xff000000));
+  CHECK(FLOAT_TO_D32QN(-150.0, 24) == int32_t(0x80000001));
+  CHECK(FLOAT_TO_D32QN(-1.0e99, 24) == int32_t(0x80000001));
+  CHECK(FLOAT_TO_D32QN(150.0, 24) == int32_t(0x7fffffff));  
+  CHECK(FLOAT_TO_D32QN(1.0e99, 24) == int32_t(0x7fffffff));  
+
+  CHECK(FLOAT_TO_D16QN(1.0, 10) == int16_t(0x0400));
+  CHECK(FLOAT_TO_D16QN(-1.0, 10) == int16_t(0xfc00));
+  CHECK(FLOAT_TO_D16QN(150.0, 10) == int16_t(0x7fff));  
+  CHECK(FLOAT_TO_D16QN(-150.0, 10) == int16_t(0x8001));
+  CHECK(FLOAT_TO_D16QN(1.0e99, 10) == int16_t(0x7fff));  
+
+  CHECK(FLOAT_TO_uD16QN(1.0, 10) == uint16_t(0x0400));
+  CHECK(FLOAT_TO_uD16QN(-1.0, 10) == uint16_t(0x0000));
+  CHECK(FLOAT_TO_uD16QN(150.0, 10) == uint16_t(0xffff));  
+  CHECK(FLOAT_TO_uD16QN(1.0e99, 10) == uint16_t(0xffff));  
+
+  CHECK(FLOAT_TO_uD8QN(1.0, 3) == uint8_t(0x08));
+  CHECK(FLOAT_TO_uD8QN(-1.0, 10) == uint8_t(0x00));
+  CHECK(FLOAT_TO_uD8QN(150.0, 10) == uint8_t(0xff));  
+  CHECK(FLOAT_TO_uD8QN(1.0e99, 10) == uint8_t(0xff));  
+}


### PR DESCRIPTION
## Description

Avoid wraparound when converting floating point values to fixed-point.
Previously, a value for Kp (the position feedback term) just above 5.0 would wrap around to 0 when converted to uint16_t. Now it gets clamped at the minimum & maximum representable value.
All the control params (Kp, Kd, i_sat, current_ref, velocity_ref, position_ref) are handled similarly.

Also add tests for the above, using the catch2 test harness. `make test` will run them.

## How I Tested

sdk/master_board_sdk/tests/test_protocol.cpp covers many cases

## I fulfilled the following requirements

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
