### PR TITLE
(Small) Fix for sdk examples with python >=3.8

### DIFF
--- a/sdk/master_board_sdk/example/com_analyser.py
+++ b/sdk/master_board_sdk/example/com_analyser.py
@@ -5,13 +5,19 @@ import math
 import os
 import sys
 import time
-from time import clock
+try:
+  from time import clock
+except(ImportError):
+  from time import process_time as clock
 
 import libmaster_board_sdk_pywrap as mbs
 import matplotlib.pyplot as plt
 from matplotlib.offsetbox import AnchoredText
 import numpy as np
-import platform
+try:
+    from platform import linux_distribution
+except(ImportError):
+    from distro import linux_distribution
 import subprocess
 
 
@@ -293,7 +299,7 @@ def example_script(name_interface):
     # creation of the text file with system info
     text_file = open("../graphs/" + dir_name + '/' + dir_name + "-system-info.txt", 'w')
     text_file.write("Current date and time: " + time.strftime("%c") + '\n')
-    text_file.write("Linux distribution: " + platform.linux_distribution()[0] + ' ' + platform.linux_distribution()[1] + ' ' + platform.linux_distribution()[2] + '\n')
+    text_file.write("Linux distribution: " + linux_distribution()[0] + ' ' + linux_distribution()[1] + ' ' + linux_distribution()[2] + '\n')
     text_file.write("Computer: " + os.uname()[1] + '\n')
     text_file.write("Interface: " + name_interface + '\n')
     if (name_interface[0] == 'w'):

--- a/sdk/master_board_sdk/example/com_analyser.py
+++ b/sdk/master_board_sdk/example/com_analyser.py
@@ -6,9 +6,9 @@ import os
 import sys
 import time
 try:
-  from time import clock
+  from time import process_time
 except(ImportError):
-  from time import process_time as clock
+  from time import clock as process_time
 
 import libmaster_board_sdk_pywrap as mbs
 import matplotlib.pyplot as plt
@@ -65,12 +65,12 @@ def example_script(name_interface):
         robot_if.GetDriver(i).SetTimeout(5)
         robot_if.GetDriver(i).Enable()
 
-    last = clock()
+    last = process_time()
     prev_time = 0
 
     while (not robot_if.IsTimeout() and not robot_if.IsAckMsgReceived()):
-        if ((clock() - last) > dt):
-            last = clock()
+        if ((process_time() - last) > dt):
+            last = process_time()
             robot_if.SendInit()
 
     if robot_if.IsTimeout():
@@ -90,7 +90,7 @@ def example_script(name_interface):
     last_cmd_packet_index = first_cmd_index
 
     while ((not robot_if.IsTimeout())
-           and (clock() < duration)):  # Stop after 15 seconds (around 5 seconds are used at the start for calibration)
+           and (process_time() < duration)):  # Stop after 15 seconds (around 5 seconds are used at the start for calibration)
 
         if (robot_if.GetLastRecvCmdIndex() > robot_if.GetCmdPacketIndex()):
             last_recv_cmd_index = (overflow_cmd_cpt-1) * 65536 + robot_if.GetLastRecvCmdIndex()
@@ -98,9 +98,9 @@ def example_script(name_interface):
             last_recv_cmd_index = overflow_cmd_cpt * 65536 + robot_if.GetLastRecvCmdIndex()
 
         if (last_recv_cmd_index >= first_cmd_index and received_list[last_recv_cmd_index-first_cmd_index] == 0):
-                received_list[last_recv_cmd_index-first_cmd_index] = clock()
+                received_list[last_recv_cmd_index-first_cmd_index] = process_time()
         
-        if ((clock() - last) > dt):
+        if ((process_time() - last) > dt):
             last += dt
             cpt += 1
 
@@ -137,9 +137,9 @@ def example_script(name_interface):
                 sensor_lost_list.append(robot_if.GetSensorsLost())
                 cmd_ratio_list.append(100.*robot_if.GetCmdLost()/robot_if.GetCmdSent())
                 sensor_ratio_list.append(100.*robot_if.GetSensorsLost()/robot_if.GetSensorsSent())
-                time_list.append(clock())
+                time_list.append(process_time())
 
-            current_time = clock()
+            current_time = process_time()
 
             diff = robot_if.GetCmdPacketIndex() - last_cmd_packet_index
             if diff < 0:

--- a/sdk/master_board_sdk/example/com_analyser.py
+++ b/sdk/master_board_sdk/example/com_analyser.py
@@ -1,10 +1,10 @@
 # coding: utf8
 
 import argparse
-import math
 import os
 import sys
 import time
+import subprocess
 try:
   from time import process_time
 except(ImportError):
@@ -14,11 +14,18 @@ import libmaster_board_sdk_pywrap as mbs
 import matplotlib.pyplot as plt
 from matplotlib.offsetbox import AnchoredText
 import numpy as np
-try:
-    from platform import linux_distribution
-except(ImportError):
-    from distro import linux_distribution
-import subprocess
+
+linux_distribution = None
+if not linux_distribution:
+    try:
+        from platform import linux_distribution
+    except(ImportError):
+        pass
+if not linux_distribution:
+    try:
+        from distro import linux_distribution
+    except(ImportError):
+        pass
 
 
 def example_script(name_interface):
@@ -299,7 +306,10 @@ def example_script(name_interface):
     # creation of the text file with system info
     text_file = open("../graphs/" + dir_name + '/' + dir_name + "-system-info.txt", 'w')
     text_file.write("Current date and time: " + time.strftime("%c") + '\n')
-    text_file.write("Linux distribution: " + linux_distribution()[0] + ' ' + linux_distribution()[1] + ' ' + linux_distribution()[2] + '\n')
+    if(linux_distribution):
+        text_file.write("Linux distribution: " + linux_distribution()[0] + ' ' + linux_distribution()[1] + ' ' + linux_distribution()[2] + '\n')
+    else:
+        text_file.write("Linux distribution: ? (`plateform` or `distro` module necessary for logging this info)\n")
     text_file.write("Computer: " + os.uname()[1] + '\n')
     text_file.write("Interface: " + name_interface + '\n')
     if (name_interface[0] == 'w'):

--- a/sdk/master_board_sdk/example/example.py
+++ b/sdk/master_board_sdk/example/example.py
@@ -4,7 +4,10 @@ import argparse
 import math
 import os
 import sys
-from time import clock
+try:
+  from time import clock
+except(ImportError):
+  from time import process_time as clock
 
 import libmaster_board_sdk_pywrap as mbs
 

--- a/sdk/master_board_sdk/example/example.py
+++ b/sdk/master_board_sdk/example/example.py
@@ -5,9 +5,9 @@ import math
 import os
 import sys
 try:
-  from time import clock
+  from time import process_time
 except(ImportError):
-  from time import process_time as clock
+  from time import clock as process_time
 
 import libmaster_board_sdk_pywrap as mbs
 
@@ -46,11 +46,11 @@ def example_script(name_interface):
         robot_if.GetDriver(i).SetTimeout(5)
         robot_if.GetDriver(i).Enable()
 
-    last = clock()
+    last = process_time()
 
     while (not robot_if.IsTimeout() and not robot_if.IsAckMsgReceived()):
-        if ((clock() - last) > dt):
-            last = clock()
+        if ((process_time() - last) > dt):
+            last = process_time()
             robot_if.SendInit()
 
     if robot_if.IsTimeout():
@@ -65,10 +65,10 @@ def example_script(name_interface):
                 motors_spi_connected_indexes.append(2 * i + 1)
 
     while ((not robot_if.IsTimeout())
-           and (clock() < 20)):  # Stop after 15 seconds (around 5 seconds are used at the start for calibration)
+           and (process_time() < 20)):  # Stop after 15 seconds (around 5 seconds are used at the start for calibration)
 
-        if ((clock() - last) > dt):
-            last = clock()
+        if ((process_time() - last) > dt):
+            last = process_time()
             cpt += 1
             t += dt
             robot_if.ParseSensorData()  # Read sensor data sent by the masterboard

--- a/sdk/master_board_sdk/example/listener.py
+++ b/sdk/master_board_sdk/example/listener.py
@@ -4,7 +4,10 @@ import argparse
 import math
 import os
 import sys
-from time import clock
+try:
+  from time import clock
+except(ImportError):
+  from time import process_time as clock
 
 import libmaster_board_sdk_pywrap as mbs
 

--- a/sdk/master_board_sdk/example/listener.py
+++ b/sdk/master_board_sdk/example/listener.py
@@ -5,9 +5,9 @@ import math
 import os
 import sys
 try:
-  from time import clock
+  from time import process_time
 except(ImportError):
-  from time import process_time as clock
+  from time import clock as process_time
 
 import libmaster_board_sdk_pywrap as mbs
 
@@ -24,12 +24,12 @@ def listener_script(name_interface):
     robot_if = mbs.MasterBoardInterface(name_interface, True)
     robot_if.Init()  # Initialization of the interface between the computer and the master board
 
-    last = clock()
+    last = process_time()
 
     while (True):
 
-        if ((clock() - last) > dt):
-            last = clock()
+        if ((process_time() - last) > dt):
+            last = process_time()
             cpt += 1
             t += dt
             robot_if.ParseSensorData()  # Read sensor data sent by the masterboard


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

Hello,
There are 2 errors (easy to fix) when running sdk examples with python >= 3.8 .
```
from time import clock
ImportError: cannot import name 'clock' from 'time' (unknown location)
```
(because it has been deprecated then removed from the lib, [see the doc](https://docs.python.org/3.7/library/time.html#time.clock)) and 
```
from platform import linux_distribution
ImportError: cannot import name 'linux_distribution' from 'platform' (/usr/lib/python3.8/platform.py)
```
(because it has also been deprecated then removed from the lib, [see the doc](https://docs.python.org/3.7/library/platform.html#platform.linux_distribution))

## Description
I replaced those imports with try catch to keep backward compatibility with previous versions.

## How I Tested
It ran in different conda env on my machine.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
