### PR TITLE
Add error, thrown by sdk, for protocol version mismatch (during init)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ firmware/sdkconfig\.old
 *.s#*
 *.b#*
 *.l#*
+.vscode

--- a/documentation/masterboard_communication.md
+++ b/documentation/masterboard_communication.md
@@ -37,7 +37,7 @@ The interface on the PC needs to support monitor mode and injection. ASUS PCE-AC
 Data packet
 -----------
 
-### Current protocol version: **3**
+### Current protocol version: **4**
 
 Both WiFi and Ethernet use the same data packet format.
 
@@ -51,14 +51,20 @@ Protocol version | Session ID |
 --- | ---
 2 bytes | 2 bytes
 
-The **Protocol version** field is used to ensure both the interface and the masterboard firmware use the same protocol. The master board checks it when receiving an **Init** packet.
+**Protocol version** : version of the protocol used by the interface. This field is used to ensure both the interface and the masterboard firmware use the same protocol. The master board checks it when receiving an **Init** packet, and sends back its own (using **Ack** packet) for the interface to also perform a check.
 
-### Ack packet (3 Bytes)
-Session ID | SPI connected
---- | --- 
-2 bytes | 1 byte
+**Session ID** : Give a unique id to this session between the computer and the masterboard (set by the interface).
 
-The **SPI connected** field contains an 8 bit integer, each bit of which tells whether or not the corresponding SPI slave is connected (Least significant bit: SPI0, most significant bit: SPI7).
+### Ack packet (5 Bytes)
+Protocol version | Session ID | SPI connected
+--- | --- | --- 
+2 bytes | 2 bytes | 1 byte
+
+**Protocol version** : version of the protocol used by the masterboard.
+
+**Session ID** : Same value as the session ID received in the init packet.
+
+**SPI connected** : This field contains an 8 bit integer, each bit of which tells whether or not the corresponding SPI slave is connected (Least significant bit: SPI0, most significant bit: SPI7).
 
 Both **Command** and **Sensor** packets encapsulate 6 BLMC µDriver SPI interface packets,  without the **Index** and **CRC** fields. Additional, sensor packets also include IMU measurement and AHRS estimation.
 

--- a/firmware/main/defines.h
+++ b/firmware/main/defines.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-#define PROTOCOL_VERSION 3
+#define PROTOCOL_VERSION 4
 
 struct sensor_data {
 	uint16_t status;
@@ -44,9 +44,9 @@ struct wifi_eth_packet_command {
 } __attribute__ ((packed));
 
 struct wifi_eth_packet_ack {
+	uint16_t protocol_version;
 	uint16_t session_id;
-	uint8_t spi_connected; // least significant bit: SPI0
-						   // most significant bit: SPI7
+	uint8_t spi_connected; // least significant bit: SPI0 - most significant bit: SPI7
 } __attribute__ ((packed));
 
 struct wifi_eth_packet_sensor {

--- a/firmware/main/masterboard_main.c
+++ b/firmware/main/masterboard_main.c
@@ -126,6 +126,8 @@ static void periodic_timer_callback(void *arg)
             wifi_eth_tx_ack.session_id = session_id;
             wifi_eth_tx_data.session_id = session_id;
 
+            wifi_eth_tx_ack.protocol_version = PROTOCOL_VERSION;
+
             // updating spi_connected in ack packet
             wifi_eth_tx_ack.spi_connected = spi_connected;
 
@@ -437,7 +439,18 @@ void wifi_eth_receive_cb(uint8_t src_mac[6], uint8_t *data, int len, char eth_or
 
         if (packet_recv->protocol_version != PROTOCOL_VERSION)
         {
-            //printf("Wrong protocol version, got %d instead of %d, ignoring init packet\n", packet_recv->protocol_version, PROTOCOL_VERSION);
+            wifi_eth_tx_ack.protocol_version = PROTOCOL_VERSION;
+            wifi_eth_tx_ack.session_id = packet_recv->session_id;
+            /* Send acknowledge packets to PC to inform version mismatch */
+            if (use_wifi)
+            {
+                wifi_send_data(&wifi_eth_tx_ack, sizeof(struct wifi_eth_packet_ack));
+            }
+            else
+            {
+                eth_send_data(&wifi_eth_tx_ack, sizeof(struct wifi_eth_packet_ack));
+            }
+            ESP_LOGW("", "Wrong protocol version, got %d instead of %d, ignoring init packet.", packet_recv->protocol_version, PROTOCOL_VERSION);
             return; // ignoring packet
         }
 

--- a/sdk/master_board_sdk/include/master_board_sdk/defines.h
+++ b/sdk/master_board_sdk/include/master_board_sdk/defines.h
@@ -83,11 +83,9 @@ struct init_packet_t
 	uint16_t session_id;
 } __attribute__((packed));
 
-struct ack_packet_t
-{
+struct ack_packet_t {
+	uint16_t protocol_version;
 	uint16_t session_id;
-	uint8_t spi_connected; // least significant bit: SPI0
-						   // most significant bit: SPI7
-} __attribute__((packed));
-
+	uint8_t spi_connected; // least significant bit: SPI0 - most significant bit: SPI7
+} __attribute__ ((packed));
 #endif

--- a/sdk/master_board_sdk/include/master_board_sdk/protocol.h
+++ b/sdk/master_board_sdk/include/master_board_sdk/protocol.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-#define PROTOCOL_VERSION 3
+#define PROTOCOL_VERSION 4
 
 /* Position of the values in the command packet */
 #define UD_COMMAND_MODE 0

--- a/sdk/master_board_sdk/src/master_board_interface.cpp
+++ b/sdk/master_board_sdk/src/master_board_interface.cpp
@@ -1,5 +1,6 @@
 #include <math.h>
 #include <signal.h>
+#include <sstream>
 #include "master_board_sdk/master_board_interface.h"
 
 MasterBoardInterface *MasterBoardInterface::instance = NULL;


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

As discussed with @thomasfla and @nim65s , here is a small feature to throw an error in the sdk if there is a protocol version mismatch.

## Description
The master-board now sends back its own protocol version in the `ack` packet : 
* On the master-board : if the protocol version of the `init` packet differs from its own protocol version, the initialization is not performed and an `ack` is sent back with its own protocol version specified.
* On the sdk side : if the init `ack` packet is received with a protocol version that differs from its own, an `std::runtime_error` is thrown.

I tried to minimize the impact on the code while adding this feature (this is debatable) by not adding any new state in the master-board state machine.

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."


## How I Tested
I flashed the code on a master board and run `example/com_analyser.py`. I check that it was indeed throwing an error during init when the protocol versions differed, and was working when there were the same.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
