### PR TITLE
Apple support for wired connection.

### DIFF
--- a/sdk/master_board_sdk/CMakeLists.txt
+++ b/sdk/master_board_sdk/CMakeLists.txt
@@ -19,7 +19,7 @@ set(PROJECT_USE_CMAKE_EXPORT TRUE)
 SET(PROJECT_VERSION_COMPUTATION_METHODS ROS_PACKAGE_XML_FILE)
 
 # --- OPTIONS ----------------------------------------
-OPTION(BUILD_PYTHON_INTERFACE "Build the python binding" ON)
+OPTION(BUILD_PYTHON_INTERFACE "Build the python binding" OFF)
 OPTION(PYTHON_STANDARD_LAYOUT "Enable standard Python package layout" ON)
 OPTION(PYTHON_DEB_LAYOUT "Enable Debian-style Python package layout" OFF)
 
@@ -47,16 +47,22 @@ ENDIF(BUILD_PYTHON_INTERFACE)
 # --- INCLUDE ----------------------------------------
 # ----------------------------------------------------
 
+
 # --- MAIN LIBRARY -------------------------------------------------------------
 SET(MASTER_BOARD_SRC
-    src/ESPNOW_manager.cpp
-    src/ESPNOW_types.cpp
     src/ETHERNET_types.cpp
     src/Link_manager.cpp
     src/master_board_interface.cpp
     src/motor.cpp
     src/motor_driver.cpp
 )
+IF (NOT APPLE)
+  LIST(APPEND MASTER_BOARD_SRC
+    src/ESPNOW_manager.cpp
+    src/ESPNOW_types.cpp
+)
+ENDIF(NOT APPLE)
+
 ADD_LIBRARY(${PROJECT_NAME} SHARED
   ${MASTER_BOARD_SRC}
 )

--- a/sdk/master_board_sdk/CMakeLists.txt
+++ b/sdk/master_board_sdk/CMakeLists.txt
@@ -1,3 +1,4 @@
+
 #
 # Copyright (c) 2019 CNRS
 #
@@ -19,7 +20,11 @@ set(PROJECT_USE_CMAKE_EXPORT TRUE)
 SET(PROJECT_VERSION_COMPUTATION_METHODS ROS_PACKAGE_XML_FILE)
 
 # --- OPTIONS ----------------------------------------
-OPTION(BUILD_PYTHON_INTERFACE "Build the python binding" OFF)
+IF(APPLE)
+  SET(BUILD_PYTHON_INTERFACE OFF CACHE BOOL "Build the python binding")
+ENDIF()
+
+OPTION(BUILD_PYTHON_INTERFACE "Build the python binding" ON)
 OPTION(PYTHON_STANDARD_LAYOUT "Enable standard Python package layout" ON)
 OPTION(PYTHON_DEB_LAYOUT "Enable Debian-style Python package layout" OFF)
 

--- a/sdk/master_board_sdk/README.md
+++ b/sdk/master_board_sdk/README.md
@@ -20,6 +20,19 @@ To disable IPV6 trafic, add this line into ``` /etc/sysctl.conf```
 net.ipv6.conf.MY_INTERFACE.disable_ipv6 = 1
 ``` 
 where MY_INTERFACE is your lan interface name.
+
+##### Optional configuration (macOS):
+To disable IPV6 and IPV4 you can use
+```
+networksetup -listnetworkserviceorder
+```
+to have the list of NetworkService (Hardware Port) related to the interface.
+
+It is then possible to switch off IPV6 with:
+```
+networksetup -setv6off NetworkService
+```
+
 #### Wifi
 Your interface should support monitor mode and injection since the procol used by the master board is not a standard wifi.
 You need to configure your interface. A script is available in the sdk folder. to use it run 

--- a/sdk/master_board_sdk/include/master_board_sdk/Link_manager.h
+++ b/sdk/master_board_sdk/include/master_board_sdk/Link_manager.h
@@ -3,6 +3,9 @@
 
 #include <string>
 #include <thread>
+#ifdef __APPLE__
+#include <net/ndrv.h>
+#endif
 
 #include "master_board_sdk/Link_types.h"
 
@@ -56,6 +59,9 @@ protected:
 	pthread_t recv_thd_id;
 	struct thread_args recv_thread_params;
 	static void *sock_recv_thread(void *p_arg);
+#ifdef __APPLE__
+        struct sockaddr_ndrv sa_ndrv;
+#endif
 };
 
 #endif

--- a/sdk/master_board_sdk/include/master_board_sdk/master_board_interface.h
+++ b/sdk/master_board_sdk/include/master_board_sdk/master_board_interface.h
@@ -4,7 +4,9 @@
 #include <mutex>
 #include <chrono>
 
+#ifndef __APPLE__
 #include "master_board_sdk/ESPNOW_manager.h"
+#endif
 #include "master_board_sdk/ETHERNET_manager.h"
 #include "master_board_sdk/defines.h"
 #include "master_board_sdk/motor_driver.h"

--- a/sdk/master_board_sdk/src/Link_manager.cpp
+++ b/sdk/master_board_sdk/src/Link_manager.cpp
@@ -7,13 +7,14 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
-#ifdef __UNIX__
+#ifdef __linux__
 #include <linux/if_arp.h>
 #include <linux/if_packet.h>
+#else
+#include <net/if_arp.h>
 #endif
 
 #include <ifaddrs.h>
-#include <net/if_arp.h>
 #include <arpa/inet.h>
 #include <assert.h>
 

--- a/sdk/master_board_sdk/src/Link_manager.cpp
+++ b/sdk/master_board_sdk/src/Link_manager.cpp
@@ -113,7 +113,7 @@ void LINK_manager::start()
                        (caddr_t)&desc, sizeof(desc))) {
           perror("setsockopt"); exit(4);
          }
-#elif
+#else
 	struct sockaddr_ll s_dest_addr;
 	struct ifreq ifr;
 
@@ -238,7 +238,7 @@ int LINK_manager::send(uint8_t *payload, int len)
                                        (struct sockaddr *)&sa_ndrv,
                                        sizeof(sa_ndrv))
 #else
-                                       NULL,0
+                                NULL,0)
 #endif
                                 );
 }
@@ -253,7 +253,7 @@ int LINK_manager::send()
 #ifdef __APPLE__
                                        (struct sockaddr *)&sa_ndrv, sizeof(sa_ndrv))
 #else
-                                NULL,0
+                                NULL,0)
 #endif
                                 );
 }

--- a/sdk/master_board_sdk/src/Link_manager.cpp
+++ b/sdk/master_board_sdk/src/Link_manager.cpp
@@ -4,11 +4,18 @@
 #include <pthread.h>
 #include <unistd.h>
 
+#include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
+#ifdef __UNIX__
 #include <linux/if_arp.h>
+#endif
+#include <ifaddrs.h>
+#include <net/if_arp.h>
 #include <arpa/inet.h>
 #include <assert.h>
+
+
 
 #include "master_board_sdk/Link_manager.h"
 
@@ -34,6 +41,79 @@ void LINK_manager::set_recv_callback(LINK_manager_callback * obj_link_manager_ca
 
 void LINK_manager::start()
 {
+#ifdef __APPLE__
+        int fd,							//file descriptor
+            bind_errno,			//bind errno
+            priority_errno; //Set priority errno
+
+        /// Creates a raw socket
+	fd = socket(PF_NDRV, SOCK_RAW, 0);
+	assert(fd != -1);
+
+        /// Find the interface specified in the argument interface.
+        struct ifaddrs *ifap = NULL;
+        bool found_if=false;
+
+        if(getifaddrs(&ifap) < 0) {
+          printf("Cannot get a list of interfaces\n");
+          return;
+        }
+
+        for(struct ifaddrs *p = ifap; p!=NULL; p=p->ifa_next) {
+          if (strcmp(p->ifa_name, interface.c_str()) == 0)
+          {
+            found_if=true;
+            break; // Go out of the for loop
+          }
+        }
+
+        if(!found_if)
+        {
+          printf("Did not find interface %s\n",interface.c_str());
+          return;
+        }
+        freeifaddrs(ifap);
+
+        /// Indicates that this program wants to use a raw socket (PF_NDRV)
+        /// wants to use interface as interface.
+	this->sa_ndrv.snd_family = PF_NDRV;
+        this->sa_ndrv.snd_len = sizeof (sa_ndrv);
+        strlcpy((char *)sa_ndrv.snd_name, interface.c_str(), sizeof (sa_ndrv.snd_name));
+
+	bind_errno = bind(fd, (struct sockaddr *)&sa_ndrv, sizeof(sa_ndrv));
+	if (bind_errno < 0)
+        {
+          printf("Unable to bind to %s\n",sa_ndrv.snd_name);
+          perror("bind:");
+          return;
+        }
+
+	priority_errno = setsockopt(fd, SOL_SOCKET, SO_NET_SERVICE_TYPE , &(this->socket_priority), sizeof(this->socket_priority));
+
+
+        // Need to set this option for receiving Ethertype packet send from the
+        // masterboard
+        struct ndrv_protocol_desc desc;
+        struct ndrv_demux_desc demux_desc[1];
+        memset(&desc, '\0', sizeof(desc));
+        memset(&demux_desc, '\0', sizeof(demux_desc));
+
+        /* Request kernel for demuxing of one chosen ethertype */
+        desc.version = NDRV_PROTOCOL_DESC_VERS;
+        desc.protocol_family = 0x88b5; // The masterboard Ethertype.
+        desc.demux_count = 1;
+        desc.demux_list = (struct ndrv_demux_desc*)&demux_desc;
+        demux_desc[0].type = NDRV_DEMUXTYPE_ETHERTYPE;
+        demux_desc[0].length = sizeof(unsigned short);
+        demux_desc[0].data.ether_type = ntohs(0x88b5);
+
+        if (setsockopt(fd,
+                       SOL_NDRVPROTO,
+                       NDRV_SETDMXSPEC,
+                       (caddr_t)&desc, sizeof(desc))) {
+          perror("setsockopt"); exit(4);
+         }
+#elif
 	struct sockaddr_ll s_dest_addr;
 	struct ifreq ifr;
 
@@ -60,7 +140,12 @@ void LINK_manager::start()
 	assert(bind_errno >= 0); //abort if error
 
 	priority_errno = setsockopt(fd, SOL_SOCKET, SO_PRIORITY, &(this->socket_priority), sizeof(this->socket_priority));
-	assert(priority_errno == 0);
+#endif
+        if (priority_errno < 0)
+        {
+          perror("Unable to set priority");
+          return;
+        }
 
 	this->sock_fd = fd;
 
@@ -148,7 +233,14 @@ int LINK_manager::send(uint8_t *payload, int len)
 
 	int raw_len = mypacket->toBytes(raw_bytes, LEN_RAWBYTES_MAX);
 
-	return static_cast<int>(sendto(this->sock_fd, raw_bytes, raw_len, 0, NULL, 0));
+	return static_cast<int>(sendto(this->sock_fd, raw_bytes, raw_len, 0,
+#ifdef __APPLE__
+                                       (struct sockaddr *)&sa_ndrv,
+                                       sizeof(sa_ndrv))
+#else
+                                       NULL,0
+#endif
+                                );
 }
 
 int LINK_manager::send()
@@ -157,5 +249,11 @@ int LINK_manager::send()
 
 	int raw_len = mypacket->toBytes(raw_bytes, LEN_RAWBYTES_MAX);
 
-	return static_cast<int>(sendto(this->sock_fd, raw_bytes, raw_len, 0, NULL, 0));
+	return static_cast<int>(sendto(this->sock_fd, raw_bytes, raw_len, 0,
+#ifdef __APPLE__
+                                       (struct sockaddr *)&sa_ndrv, sizeof(sa_ndrv))
+#else
+                                NULL,0
+#endif
+                                );
 }

--- a/sdk/master_board_sdk/src/Link_manager.cpp
+++ b/sdk/master_board_sdk/src/Link_manager.cpp
@@ -146,8 +146,8 @@ void LINK_manager::start()
 #endif
         if (priority_errno < 0)
         {
-          perror("Unable to set priority");
-          return;
+          perror("Unable to start because the program could not set priority on low level link");
+          assert(false);
         }
 
 	this->sock_fd = fd;

--- a/sdk/master_board_sdk/src/Link_manager.cpp
+++ b/sdk/master_board_sdk/src/Link_manager.cpp
@@ -9,7 +9,9 @@
 #include <sys/ioctl.h>
 #ifdef __UNIX__
 #include <linux/if_arp.h>
+#include <linux/if_packet.h>
 #endif
+
 #include <ifaddrs.h>
 #include <net/if_arp.h>
 #include <arpa/inet.h>

--- a/sdk/master_board_sdk/src/master_board_interface.cpp
+++ b/sdk/master_board_sdk/src/master_board_interface.cpp
@@ -65,12 +65,14 @@ int MasterBoardInterface::Init()
   }
   else if (if_name_[0] == 'w')
   {
+#ifndef __APPLE__
     /*WiFi*/
     printf("Using WiFi (%s)\n", if_name_.c_str());
     link_handler_ = new ESPNOW_manager(if_name_, DATARATE_24Mbps, CHANNEL_freq_9, my_mac_, dest_mac_, false); //TODO write setter for espnow specific parametters
     link_handler_->set_recv_callback(this);
     link_handler_->start();
     ((ESPNOW_manager *)link_handler_)->bind_filter();
+#endif
   }
   else
   {
@@ -129,7 +131,11 @@ int MasterBoardInterface::SendInit()
     return -1; // Return -1 since the command has not been sent.
   }
 
-  link_handler_->send((uint8_t *)&init_packet, sizeof(init_packet_t));
+  int r=link_handler_->send((uint8_t *)&init_packet, sizeof(init_packet_t));
+
+  if (r<0)
+  { perror("Packet send error"); }
+
   return 0;
 }
 


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."

Port Link_manager.cpp to support macOS wired connection.
ESPNow is disabled for now. (BPF filter exists on MacOS but in a way that would required more work and hence a separate PR)

## How I Tested

[//]: # "Explain how you tested your changes"

I tested this PR on a MacBookPro 2019 Ventura 13.2.1, a USB-C / Ethernet connector, a [Dual motor testbed](https://github.com/open-dynamic-robot-initiative/open_robot_actuator_hardware/blob/master/mechanics/dual_motor_testbed_v1/README.md#dual-motor-testbed-v1), and 
```
master_board_example INTERFACE
```

## Do not merge before

[//]: # "Link other open pull request here that need to be merged first."
[//]: # "Remove this section if it does not apply."

This PR compiled on Linux but has not been tested on Linux.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [ ] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
I did not find the clang-format file...
- [X] All new functions/classes are documented and existing documentation is updated according to changes.
- [X] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
