### PR TITLE
Add Python bindings for SetKp/Kd/SaturationCurrent and fix example.py

### DIFF
--- a/sdk/master_board_sdk/example/example.py
+++ b/sdk/master_board_sdk/example/example.py
@@ -4,7 +4,7 @@ import argparse
 import math
 import os
 import sys
-from time import clock
+from time import perf_counter
 
 import libmaster_board_sdk_pywrap as mbs
 
@@ -43,11 +43,12 @@ def example_script(name_interface):
         robot_if.GetDriver(i).SetTimeout(5)
         robot_if.GetDriver(i).Enable()
 
-    last = clock()
+    start = perf_counter()
+    last = start
 
     while (not robot_if.IsTimeout() and not robot_if.IsAckMsgReceived()):
-        if ((clock() - last) > dt):
-            last = clock()
+        if ((perf_counter() - last) > dt):
+            last = perf_counter()
             robot_if.SendInit()
 
     if robot_if.IsTimeout():
@@ -61,11 +62,12 @@ def example_script(name_interface):
                 motors_spi_connected_indexes.append(2 * i)
                 motors_spi_connected_indexes.append(2 * i + 1)
 
+    # Stop after 15 seconds (around 5 seconds are used at the start for calibration)
     while ((not robot_if.IsTimeout())
-           and (clock() < 20)):  # Stop after 15 seconds (around 5 seconds are used at the start for calibration)
+           and (perf_counter() - start < 20)):
 
-        if ((clock() - last) > dt):
-            last = clock()
+        if ((perf_counter() - last) > dt):
+            last = perf_counter()
             cpt += 1
             t += dt
             robot_if.ParseSensorData()  # Read sensor data sent by the masterboard

--- a/sdk/master_board_sdk/example/example.py
+++ b/sdk/master_board_sdk/example/example.py
@@ -35,8 +35,18 @@ def example_script(name_interface):
     robot_if = mbs.MasterBoardInterface(name_interface)
     robot_if.Init()  # Initialization of the interface between the computer and the master board
     for i in range(N_SLAVES_CONTROLED):  #  We enable each controler driver and its two associated motors
+        # initialise command to zero
         robot_if.GetDriver(i).motor1.SetCurrentReference(0)
+        robot_if.GetDriver(i).motor1.SetPositionReference(0)
+        robot_if.GetDriver(i).motor1.SetVelocityReference(0)
+        robot_if.GetDriver(i).motor1.SetKp(0)
+        robot_if.GetDriver(i).motor1.SetKd(0)
         robot_if.GetDriver(i).motor2.SetCurrentReference(0)
+        robot_if.GetDriver(i).motor2.SetPositionReference(0)
+        robot_if.GetDriver(i).motor2.SetVelocityReference(0)
+        robot_if.GetDriver(i).motor2.SetKp(0)
+        robot_if.GetDriver(i).motor2.SetKd(0)
+
         robot_if.GetDriver(i).motor1.Enable()
         robot_if.GetDriver(i).motor2.Enable()
         robot_if.GetDriver(i).EnablePositionRolloverError()

--- a/sdk/master_board_sdk/srcpy/my_bindings_headr.cpp
+++ b/sdk/master_board_sdk/srcpy/my_bindings_headr.cpp
@@ -71,9 +71,9 @@ boost::python::tuple wrap_adc(MotorDriver const * motDriver)
             .def("SetVelocityReference", &Motor::SetVelocityReference)
             .def("SetPositionReference", &Motor::SetPositionReference)
             .def("SetPositionOffset", &Motor::SetPositionOffset)
-            // .def("SetKp", &Motor::SetKp) // Not defined in motor.cpp but declared in motor.h
-            // .def("SetKd", &Motor::SetKd) // Not defined in motor.cpp but declared in motor.h
-            // .def("SetSaturationCurrent", &Motor::SetSaturationCurrent) // Not defined in motor.cpp but declared in motor.h
+            .def("SetKp", &Motor::SetKp)
+            .def("SetKd", &Motor::SetKd)
+            .def("SetSaturationCurrent", &Motor::SetSaturationCurrent)
             .def("SetDriver", &Motor::SetDriver)
             .def("Print", &Motor::Print)
             .def("Enable", &Motor::Enable)


### PR DESCRIPTION
## Description

- Add missing Python bindings for `Motor::SetKp/Kd/SaturationCurrent`.
- Use `perf_counter()` instead of `clock()` in example.py (`clock()` is not available anymore in recent Python versions).
- Explicitly initialise all reference values and gains to zero in example.py.  This should not really be needed anymore since values are now already zero-initialised in `Motor` but better be safe than sorry.


## How I Tested

By running example.py

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
