### PR TITLE
Add ament_cmake build_type export in package.xml and install package.xml file

### DIFF
--- a/sdk/master_board_sdk/CMakeLists.txt
+++ b/sdk/master_board_sdk/CMakeLists.txt
@@ -27,10 +27,6 @@ if(APPLE)
       CACHE BOOL "Build the python binding")
 endif()
 
-# --- DETECTING ROS 1 and 2 ---
-if(DEFINED ENV{ROS_VERSION})
-  set(ROS_VERSION $ENV{ROS_VERSION})
-endif()
 
 option(BUILD_PYTHON_INTERFACE "Build the python binding" ON)
 option(PYTHON_STANDARD_LAYOUT "Enable standard Python package layout" ON)
@@ -49,9 +45,6 @@ check_minimal_cxx_standard(11 ENFORCE)
 # --- DEPENDENCIES -----------------------------------
 # ----------------------------------------------------
 
-if(ROS_VERSION EQUAL 2)
-  add_project_dependency(ament_cmake REQUIRED)
-endif()
 
 # Set component to fetch from boost Get the python interface for the bindings
 if(BUILD_PYTHON_INTERFACE)
@@ -143,6 +136,26 @@ if(BUILD_TESTING)
 endif()
 
 # --- Call ROS-2 if possible ---
-if(ROS_VERSION EQUAL 2)
-  ament_package()
-endif()
+# Allows Colcon to find non-Ament packages when using workspace underlays
+file(
+  WRITE
+  ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME}
+  "")
+install(
+  FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME}
+  DESTINATION share/ament_index/resource_index/packages)
+file(
+  WRITE
+  ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/ament_prefix_path.dsv
+  "prepend-non-duplicate;AMENT_PREFIX_PATH;")
+install(
+  FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/ament_prefix_path.dsv
+  DESTINATION share/${PROJECT_NAME}/hook)
+file(WRITE
+     ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/python_path.dsv
+     "prepend-non-duplicate;PYTHONPATH;${PYTHON_SITELIB}")
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/python_path.dsv
+  DESTINATION share/${PROJECT_NAME}/hook)

--- a/sdk/master_board_sdk/CMakeLists.txt
+++ b/sdk/master_board_sdk/CMakeLists.txt
@@ -76,7 +76,7 @@ install(
 install(DIRECTORY include/ DESTINATION include)
 
 install(FILES package.xml
-  DESTINATION ${CMAKE_INSTALL_PREFIX}/share/${PROJECT_NAME})
+  DESTINATION share/${PROJECT_NAME})
 # --- BINDINGS -----------------------------------------------------------------
 
 if(BUILD_PYTHON_INTERFACE)

--- a/sdk/master_board_sdk/CMakeLists.txt
+++ b/sdk/master_board_sdk/CMakeLists.txt
@@ -135,7 +135,6 @@ if(BUILD_TESTING)
   target_link_libraries(test_protocol PRIVATE Catch2::Catch2WithMain)
 endif()
 
-# --- Call ROS-2 if possible ---
 # Allows Colcon to find non-Ament packages when using workspace underlays
 file(
   WRITE

--- a/sdk/master_board_sdk/CMakeLists.txt
+++ b/sdk/master_board_sdk/CMakeLists.txt
@@ -73,6 +73,8 @@ install(
   DESTINATION lib)
 install(DIRECTORY include/ DESTINATION include)
 
+install(FILES package.xml
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/share/${PROJECT_NAME})
 # --- BINDINGS -----------------------------------------------------------------
 
 if(BUILD_PYTHON_INTERFACE)

--- a/sdk/master_board_sdk/CMakeLists.txt
+++ b/sdk/master_board_sdk/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2019 CNRS
 #
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10)
 
 # ----------------------------------------------------
 # --- CXX FLAGS --------------------------------------
@@ -27,6 +27,11 @@ if(APPLE)
       CACHE BOOL "Build the python binding")
 endif()
 
+# --- DETECTING ROS 1 and 2 ---
+if(DEFINED ENV{ROS_VERSION})
+  set(ROS_VERSION $ENV{ROS_VERSION})
+endif()
+
 option(BUILD_PYTHON_INTERFACE "Build the python binding" ON)
 option(PYTHON_STANDARD_LAYOUT "Enable standard Python package layout" ON)
 option(PYTHON_DEB_LAYOUT "Enable Debian-style Python package layout" OFF)
@@ -43,6 +48,10 @@ check_minimal_cxx_standard(11 ENFORCE)
 # ----------------------------------------------------
 # --- DEPENDENCIES -----------------------------------
 # ----------------------------------------------------
+
+if(ROS_VERSION EQUAL 2)
+  add_project_dependency(ament_cmake REQUIRED)
+endif()
 
 # Set component to fetch from boost Get the python interface for the bindings
 if(BUILD_PYTHON_INTERFACE)
@@ -131,4 +140,9 @@ if(BUILD_TESTING)
   endif()
   add_unit_test(test_protocol tests/test_protocol.cpp)
   target_link_libraries(test_protocol PRIVATE Catch2::Catch2WithMain)
+endif()
+
+# --- Call ROS-2 if possible ---
+if(ROS_VERSION EQUAL 2)
+  ament_package()
 endif()

--- a/sdk/master_board_sdk/package.xml
+++ b/sdk/master_board_sdk/package.xml
@@ -16,6 +16,7 @@
     <depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</depend>
     <depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</depend>
     <depend condition="$ROS_PYTHON_VERSION == 3">libboost-python-dev</depend>
+    <depend condition="$ROS_VERSION == 2">ament_cmake</depend>
 
     <depend>git</depend>
     <export>

--- a/sdk/master_board_sdk/package.xml
+++ b/sdk/master_board_sdk/package.xml
@@ -18,5 +18,7 @@
     <depend condition="$ROS_PYTHON_VERSION == 3">libboost-python-dev</depend>
 
     <depend>git</depend>
-    <export></export>
+    <export>
+      <build_type>ament_cmake</build_type>
+    </export>
 </package>

--- a/sdk/master_board_sdk/package.xml
+++ b/sdk/master_board_sdk/package.xml
@@ -16,10 +16,9 @@
     <depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</depend>
     <depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</depend>
     <depend condition="$ROS_PYTHON_VERSION == 3">libboost-python-dev</depend>
-    <depend condition="$ROS_VERSION == 2">ament_cmake</depend>
 
     <depend>git</depend>
     <export>
-      <build_type>ament_cmake</build_type>
+      <build_type>cmake</build_type>
     </export>
 </package>


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Descrition

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."
This PR is mostly to make the package ```master_board_sdk``` more compliant to ROS-2.
It allows to have a better ROS-2 settings by:
- Add ```ament_cmake```build_type in the file ```package.xml```. Not doing this will prevent ```colcon``` to create the hooks for having the package  in the ROS-2  environment variables.
- Add installation procedure in ```CMakeLists.txt```

## How I Tested

[//]: # "Explain how you tested your changes"
This does not affect the other tests.
Checked if ```package.xml``` was installed, and did:
```
colcon build --packages-select master_board_sdk --cmake-args ' -DCMAKE_BUILD_TYPE=RELEASE'
export COLCON_STRACE=1
source ./install/setup.zsh
```
```master_board_sdk``` appears in ```AMENT_CMAKE_PATH```


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [X] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings). Used pre-commit
- [X] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
