### PR TITLE
Fix two bugs (FLOAT_TO_D8QN and compiling issue) + remove warnings on the core library.

### DIFF
--- a/sdk/master_board_sdk/include/master_board_sdk/protocol.h
+++ b/sdk/master_board_sdk/include/master_board_sdk/protocol.h
@@ -135,7 +135,7 @@
 
 #define FLOAT_TO_D32QN(a,n)       ((int32_t) std::min(std::max(((a) * (1<<(n))), -2147483647.0), 2147483647.0))
 #define FLOAT_TO_D16QN(a,n)       ((int16_t) std::min(std::max((a) * (1<<(n)), -32767.0), 32767.0))
-#define FLOAT_TO_D8QN(a,n)        ((int8_t)  std::min(std::max(((a) * (1<<(n))), -127.0, +127.0)))
+#define FLOAT_TO_D8QN(a,n)        ((int8_t)  std::min(std::max(((a) * (1<<(n))), -127.0), +127.0))
 
 
 #endif

--- a/sdk/master_board_sdk/src/ETHERNET_types.cpp
+++ b/sdk/master_board_sdk/src/ETHERNET_types.cpp
@@ -13,16 +13,17 @@ void ETHERNET_packet::set_dst_mac(uint8_t dst_mac[6]) {
 	memcpy(this->data.dst_mac, dst_mac, sizeof(uint8_t)*6);
 }
 
-int ETHERNET_packet::toBytes(uint8_t *bytes, int max_len) {	
+int ETHERNET_packet::toBytes(uint8_t *bytes, int max_len) {
 	int correct_len = static_cast<int>(sizeof(ETHERNET_data)) + this->data.length - 0xff;
 	int padded_len = max(correct_len, ETH_SEND_SIZE_MIN);
-	
-	assert(padded_len <= max_len); 
 
-	memcpy(bytes, &(this->data), correct_len);	
-	
+	assert(padded_len <= max_len);
+
+	memcpy(bytes, &(this->data), static_cast<size_t>(correct_len));
+
 	if(padded_len > correct_len) {
-		memset(bytes + correct_len, 0, padded_len - correct_len);
+		memset(bytes + correct_len, 0,
+                       static_cast<size_t>(padded_len - correct_len));
 	}
 
 	return padded_len;
@@ -54,6 +55,6 @@ int ETHERNET_packet::get_payload_len_FromRaw(uint8_t *raw_bytes, int len) {
 
 uint8_t* ETHERNET_packet::get_payload_FromRaw(uint8_t *raw_bytes, int len) {
 	if(len < ETH_RECV_SIZE_MIN + 1) return NULL;
-	
+
 	return ((ETHERNET_data *) raw_bytes)->payload;
 }

--- a/sdk/master_board_sdk/src/Link_manager.cpp
+++ b/sdk/master_board_sdk/src/Link_manager.cpp
@@ -232,11 +232,13 @@ int LINK_manager::send(uint8_t *payload, int len)
 	//Not the most fastest way to do this :
 	//	copy the payload in the packet array and then copy it back into the buffer...
 	this->mypacket->set_payload_len(len);
-	memcpy(this->mypacket->get_payload_ptr(), payload, len);
+	memcpy(this->mypacket->get_payload_ptr(), payload,
+               static_cast<size_t>(len));
 
 	int raw_len = mypacket->toBytes(raw_bytes, LEN_RAWBYTES_MAX);
 
-	return static_cast<int>(sendto(this->sock_fd, raw_bytes, raw_len, 0,
+	return static_cast<int>(sendto(this->sock_fd, raw_bytes,
+                                       static_cast<size_t>(raw_len), 0,
 #ifdef __APPLE__
                                        (struct sockaddr *)&sa_ndrv,
                                        sizeof(sa_ndrv))
@@ -252,7 +254,8 @@ int LINK_manager::send()
 
 	int raw_len = mypacket->toBytes(raw_bytes, LEN_RAWBYTES_MAX);
 
-	return static_cast<int>(sendto(this->sock_fd, raw_bytes, raw_len, 0,
+	return static_cast<int>(sendto(this->sock_fd, raw_bytes,
+                                       static_cast<size_t>(raw_len), 0,
 #ifdef __APPLE__
                                        (struct sockaddr *)&sa_ndrv, sizeof(sa_ndrv))
 #else

--- a/sdk/master_board_sdk/src/master_board_interface.cpp
+++ b/sdk/master_board_sdk/src/master_board_interface.cpp
@@ -260,7 +260,7 @@ void MasterBoardInterface::callback(uint8_t /*src_mac*/[6], uint8_t *data, int l
           << " while board expects "
           << p_ack_packet->protocol_version
           << ")";
-      printf("%s\n", err_msg.str());
+      printf("%s\n", err_msg.str().c_str());
       throw std::runtime_error( err_msg.str());
       return;
     }

--- a/sdk/master_board_sdk/src/master_board_interface.cpp
+++ b/sdk/master_board_sdk/src/master_board_interface.cpp
@@ -202,12 +202,12 @@ int MasterBoardInterface::SendCommand()
     command_packet.dual_motor_driver_command_packets[i].velocity_ref[1] = FLOAT_TO_D16QN(motor_drivers[i].motor2->velocity_ref * 60. / (2. * M_PI * 1000.), UD_QN_VEL);
     command_packet.dual_motor_driver_command_packets[i].current_ref[0] = FLOAT_TO_D16QN(motor_drivers[i].motor1->current_ref, UD_QN_IQ);
     command_packet.dual_motor_driver_command_packets[i].current_ref[1] = FLOAT_TO_D16QN(motor_drivers[i].motor2->current_ref, UD_QN_IQ);
-    command_packet.dual_motor_driver_command_packets[i].kp[0] = FLOAT_TO_uD16QN(2. * M_PI * motor_drivers[i].motor1->kp, UD_QN_KP);
-    command_packet.dual_motor_driver_command_packets[i].kp[1] = FLOAT_TO_uD16QN(2. * M_PI * motor_drivers[i].motor2->kp, UD_QN_KP);
-    command_packet.dual_motor_driver_command_packets[i].kd[0] = FLOAT_TO_uD16QN(((2. * M_PI * 1000.)/60.0) * motor_drivers[i].motor1->kd, UD_QN_KD);
-    command_packet.dual_motor_driver_command_packets[i].kd[1] = FLOAT_TO_uD16QN(((2. * M_PI * 1000.)/60.0) * motor_drivers[i].motor2->kd, UD_QN_KD);
-    command_packet.dual_motor_driver_command_packets[i].i_sat[0] = FLOAT_TO_uD8QN(motor_drivers[i].motor1->current_sat, UD_QN_ISAT);
-    command_packet.dual_motor_driver_command_packets[i].i_sat[1] = FLOAT_TO_uD8QN(motor_drivers[i].motor2->current_sat, UD_QN_ISAT);
+    command_packet.dual_motor_driver_command_packets[i].kp[0] = FLOAT_TO_D16QN(2. * M_PI * motor_drivers[i].motor1->kp, UD_QN_KP);
+    command_packet.dual_motor_driver_command_packets[i].kp[1] = FLOAT_TO_D16QN(2. * M_PI * motor_drivers[i].motor2->kp, UD_QN_KP);
+    command_packet.dual_motor_driver_command_packets[i].kd[0] = FLOAT_TO_D16QN(((2. * M_PI * 1000.)/60.0) * motor_drivers[i].motor1->kd, UD_QN_KD);
+    command_packet.dual_motor_driver_command_packets[i].kd[1] = FLOAT_TO_D16QN(((2. * M_PI * 1000.)/60.0) * motor_drivers[i].motor2->kd, UD_QN_KD);
+    command_packet.dual_motor_driver_command_packets[i].i_sat[0] = FLOAT_TO_D8QN(motor_drivers[i].motor1->current_sat, UD_QN_ISAT);
+    command_packet.dual_motor_driver_command_packets[i].i_sat[1] = FLOAT_TO_D8QN(motor_drivers[i].motor2->current_sat, UD_QN_ISAT);
   }
 
   // Current time point


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

This PR fixes three aspects:
 * FLOAT_TO_D8QN is currently wrong, the bracket is not at the right position (found during warning shooting)
 * ```printf("%s\n",err_msg.str())```does not work with clang. Introduced in commit 782c348. Fixed in this PR.
 * Remove warnings in the core library (mostly through cast or by using appropriate MACRO)
 * This PR does not fix warning in Catch2 as this should be done upstream
 
## How I Tested

[//]: # "Explain how you tested your changes"

```colcon test --packages-select master_board_sdk```


[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [X] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [X] (NA) All new functions/classes are documented and existing documentation is updated according to changes.
- [X] (NA) No commented code from testing/debugging is kept (unless there is a good reason to keep it).
