### PR TITLE
Update cmake

### DIFF
--- a/sdk/master_board_sdk/CMakeLists.txt
+++ b/sdk/master_board_sdk/CMakeLists.txt
@@ -75,6 +75,7 @@ if(BUILD_PYTHON_INTERFACE)
   set(PYTHON_COMPONENTS Interpreter Development.Module)
   findpython(REQUIRED)
   set_boost_default_options()
+  search_for_boost_python(REQUIRED)
 endif(BUILD_PYTHON_INTERFACE)
 
 # ----------------------------------------------------

--- a/sdk/master_board_sdk/CMakeLists.txt
+++ b/sdk/master_board_sdk/CMakeLists.txt
@@ -26,14 +26,33 @@ option(PYTHON_DEB_LAYOUT "Enable Debian-style Python package layout" OFF)
 
 # Check if the submodule cmake have been initialized
 set(JRL_CMAKE_MODULES "${CMAKE_CURRENT_LIST_DIR}/cmake")
-if(NOT EXISTS "${CMAKE_SOURCE_DIR}/cmake/base.cmake")
-  message(STATUS "JRL cmakemodules not found. Let's fetch it.")
-  include(FetchContent)
-  FetchContent_Declare(
-    "jrl-cmakemodules"
-    GIT_REPOSITORY "https://github.com/jrl-umi3218/jrl-cmakemodules.git")
-  FetchContent_MakeAvailable("jrl-cmakemodules")
-  FetchContent_GetProperties("jrl-cmakemodules" SOURCE_DIR JRL_CMAKE_MODULES)
+if(EXISTS "${JRL_CMAKE_MODULES}/base.cmake")
+  message(STATUS "JRL cmakemodules found in 'cmake/' git submodule")
+else()
+  find_package(jrl-cmakemodules QUIET CONFIG)
+  if(jrl-cmakemodules_FOUND)
+    get_property(
+      JRL_CMAKE_MODULES
+      TARGET jrl-cmakemodules::jrl-cmakemodules
+      PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+    message(STATUS "JRL cmakemodules found on system at ${JRL_CMAKE_MODULES}")
+  elseif(${CMAKE_VERSION} VERSION_LESS "3.14.0")
+    message(
+      FATAL_ERROR
+        "\nCan't find jrl-cmakemodules. Please either:\n"
+        "  - use git submodule: 'git submodule update --init'\n"
+        "  - or install https://github.com/jrl-umi3218/jrl-cmakemodules\n"
+        "  - or upgrade your CMake version to >= 3.14 to allow automatic fetching\n"
+    )
+  else()
+    message(STATUS "JRL cmakemodules not found. Let's fetch it.")
+    include(FetchContent)
+    FetchContent_Declare(
+      "jrl-cmakemodules"
+      GIT_REPOSITORY "https://github.com/jrl-umi3218/jrl-cmakemodules.git")
+    FetchContent_MakeAvailable("jrl-cmakemodules")
+    FetchContent_GetProperties("jrl-cmakemodules" SOURCE_DIR JRL_CMAKE_MODULES)
+  endif()
 endif()
 
 include("${JRL_CMAKE_MODULES}/base.cmake")


### PR DESCRIPTION
Python module was broken on @ConstantRoux:
```
croux@unzen:~ $ python -c "import libmaster_board_sdk_pywrap"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: …/install/lib/python3.10/site-packages/libmaster_board_sdk_pywrap.cpython-310-x86_64-linux-gnu.so: undefined symbol: _ZNK5boost6python7objects21py_function_impl_base9max_arityEv
```
This can be explained by the lack of link to boost python:
```
croux@unzen:~ $ ldd …/install/lib/python3.10/site-packages/libmaster_board_sdk_pywrap.cpython-310-x86_64-linux-gnu.so
        linux-vdso.so.1 (0x00007ffef79d7000)
        libmaster_board_sdk.so => …/install/lib/python3.10/site-packages/../../../lib/libmaster_board_sdk.so (0x00007f1417695000)
        libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f14173f4000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f14173d0000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f14171a7000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f14170be000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f1417774000)
```

So I'm adding `search_for_boost_python` to fix that. While here, update the submodule a bit.
